### PR TITLE
Added 2 tour steps for datapath and showed link b/w instruction and sequence of RTL micro-instructions

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -244,6 +244,10 @@ footer {
     background-color: #ADF;
 }
 
+.highlighted-line {
+    background-color: #EEE;
+}
+
 .current-pc {
     background-color: #0F0 !important;
 }

--- a/src/js/interface.js
+++ b/src/js/interface.js
@@ -25,7 +25,8 @@ window.addEventListener("load", function() {
         uploadButton = document.getElementById("upload"),
         fileInput = document.getElementById("fileInput"),
         datapathEle = document.getElementById("datapath-diagram"),
-        datapathInstructionElement = document.getElementById("datapath-display-instructions");
+        datapathInstructionElement = document.getElementById("datapath-display-instructions"),
+        currentInstructionRegisterLog = null;
 
     const HEX = 0, DEC = 1, ASCII = 2;
     var minDatapathDelay = parseInt(localStorage.getItem("min-datapath-delay")) || 1000;
@@ -379,8 +380,8 @@ window.addEventListener("load", function() {
 
         var shouldScrollToBottomRegisterLog = registerLogOuter.clientHeight === (registerLogOuter.scrollHeight - registerLogOuter.scrollTop);
 
-        registerLog.appendChild(document.createTextNode(message));
-        registerLog.appendChild(document.createElement("br"));
+        currentInstructionRegisterLog.appendChild(document.createTextNode(message));
+        currentInstructionRegisterLog.appendChild(document.createElement("br"));
 
         if(shouldScrollToBottomRegisterLog) {
             registerLogOuter.scrollTop = registerLogOuter.scrollHeight;
@@ -644,6 +645,36 @@ window.addEventListener("load", function() {
             if(!running || delay >= minDatapathDelay) {
                 datapath.showInstruction();
             }
+
+            var currentInstruction = sim.current();
+
+            console.log(currentInstruction);
+
+            currentInstructionRegisterLog = document.createElement("div");
+
+            currentInstructionRegisterLog.addEventListener("mouseover", function() {
+                this.style.background = "#eee";
+            });
+
+            currentInstructionRegisterLog.addEventListener("mouseout", function() {
+                this.style.background = "transparent";
+            });
+
+            if(currentInstruction && typeof currentInstruction.line !== "undefined") {
+                currentInstructionRegisterLog.dataset.currentLine = currentInstruction.line;
+
+                currentInstructionRegisterLog.addEventListener("mouseover", function() {
+                    var line = parseInt(this.dataset.currentLine);
+                    programCodeMirror.addLineClass(line, "background", "highlighted-line");
+                }, false);
+
+                currentInstructionRegisterLog.addEventListener("mouseout", function() {
+                    var line = parseInt(this.dataset.currentLine);
+                    programCodeMirror.removeLineClass(line, "background", "highlighted-line");
+                }, false);
+            }
+
+            registerLog.appendChild(currentInstructionRegisterLog);
         });
         sim.setEventListener("reglog", regLogFunc);
         sim.setEventListener("decode", function(old) {

--- a/src/js/tour.js
+++ b/src/js/tour.js
@@ -1,111 +1,148 @@
-$(document).ready( function(){
-    try{
-            var tour = new Tour({
-                steps: [
-                {
-                    smartPlacement: true,
-                    element: "#brand",
-                    title: "Welcome to MARIE.js",
-                    content: "This tour introduces the features and how to use MARIE.js"
-                },
-                {
-                    smartPlacement: true,
-                    backdrop: true,
-                    element: "#program-container",
-                    title: "Coding Area",
-                    content: "This is where you type your code here"
-                },
-                {
-                    smartPlacement: true,
-                    backdrop: true,
-                    element: "#register-container",
-                    title: "Registers",
-                    content: "This shows you the register values"
-                },
-                {
-                    smartPlacement: true,
-                    backdrop: true,
-                    element: "#tab-container",
-                    title: "Values and Outputs",
-                    content: "This shows you the output in Register Log, Output Values and how the data is being transferred in RTL"
-                },
-                {
-                    smartPlacement: true,
-                    backdrop: true,
-                    element: "#status-info",
-                    title: "Status",
-                    content: "Shows you current status: also shows error messages"
-                },
-                {
-                    smartPlacement: true,
-                    element: "#bottom-menu",
-                    title: "Control Bar",
-                    content: "This is the bar used for stepping through the code, and building it"
-                },
-                {
-                    smartPlacement: true,
-                    element: "#assemble",
-                    title: "Assembling the Code",
-                    content: "Build the code here"
-                },
-                {
-                    smartPlacement: true,
-                    element: "#step",
-                    title: "Step",
-                    content: "Step Through the Code using this button"
-                },
-                {
-                    smartPlacement: true,
-                    element: "#microstep",
-                    title: "Microstep",
-                    content: "Step thorugh the code by each individual command here"
-                },
-                {
-                    smartPlacement: true,
-                    element: "#step-back",
-                    title: "Stepping Backwards through the Code",
-                    content: "This is an awesome debugging feature where you can step back through each individual line to see where you've gone wrong"
-                },
-                {
-                    smartPlacement: true,
-                    element: "#run",
-                    title: "Run",
-                    content: "Run the code, what else? This button can also pause the current execution during code execution"
-                },
-                {
-                    smartPlacement: true,
-                    element: "#restart",
-                    title: "Restart",
-                    content: "Have you tried turning it on and off again? This does exactly that. But this also preserves memory contents"
-                },
-                {
-                    smartPlacement: true,
-                    element: "#delay-slider",
-                    title: "Delay Slider",
-                    content: "This slider sets the timing of the execution of each step"
-                },
-                {
-                    smartPlacement: true,
-                    element: "#output-select",
-                    title: "Select Output Type",
-                    content: "Change the output type here with the options (HEX - Base 8, DEC - Base 10, ASCII - Base 16) . This by default is set to HEX. ",
-                }
-                ]});
-            // Initialize the tour
-            tour.init();
+$(document).ready(function() {
+    function viewHome() {
+        window.location.hash = "";
+    }
 
-            // Start the tour
-            tour.start(); 
+    function viewDatapath() {
+        window.location.hash = "#datapath";
     }
-    catch(ex){
-        console.log(ex);
+
+    try {
+        var tour = new Tour({
+            steps: [
+            {
+                onShow: viewHome,
+                smartPlacement: true,
+                element: "#brand",
+                title: "Welcome to MARIE.js",
+                content: "This tour introduces the features and how to use MARIE.js"
+            },
+            {
+                onShow: viewHome,
+                smartPlacement: true,
+                backdrop: true,
+                element: "#program-container",
+                title: "Coding Area",
+                content: "This is where you type your code here"
+            },
+            {
+                onShow: viewHome,
+                smartPlacement: true,
+                backdrop: true,
+                element: "#register-container",
+                title: "Registers",
+                content: "This shows you the register values"
+            },
+            {
+                onShow: viewHome,
+                smartPlacement: true,
+                backdrop: true,
+                element: "#tab-container",
+                title: "Values and Outputs",
+                content: "This shows you the output in Register Log, Output Values and how the data is being transferred in RTL"
+            },
+            {
+                onShow: viewHome,
+                smartPlacement: true,
+                backdrop: true,
+                element: "#status-info",
+                title: "Status bar",
+                content: "Shows you current status: also shows error messages"
+            },
+            {
+                onShow: viewHome,
+                smartPlacement: true,
+                element: "#bottom-menu",
+                title: "Control Bar",
+                content: "This is the bar used for stepping through the code, and building it"
+            },
+            {
+                onShow: viewHome,
+                smartPlacement: true,
+                element: "#assemble",
+                title: "Assembling the Code",
+                content: "Build the code here"
+            },
+            {
+                onShow: viewHome,
+                smartPlacement: true,
+                element: "#step",
+                title: "Step",
+                content: "Step Through the Code using this button"
+            },
+            {
+                onShow: viewHome,
+                smartPlacement: true,
+                element: "#microstep",
+                title: "Microstep",
+                content: "Step thorugh the code by each individual command here"
+            },
+            {
+                onShow: viewHome,
+                smartPlacement: true,
+                element: "#step-back",
+                title: "Stepping Backwards through the Code",
+                content: "This is an awesome debugging feature where you can step back through each individual line to see where you've gone wrong"
+            },
+            {
+                onShow: viewHome,
+                smartPlacement: true,
+                element: "#run",
+                title: "Run",
+                content: "Run the code, what else? This button can also pause the current execution during code execution"
+            },
+            {
+                onShow: viewHome,
+                smartPlacement: true,
+                element: "#restart",
+                title: "Restart",
+                content: "Have you tried turning it on and off again? This does exactly that. But this also preserves memory contents"
+            },
+            {
+                onShow: viewHome,
+                smartPlacement: true,
+                element: "#delay-slider",
+                title: "Delay Slider",
+                content: "This slider sets the timing of the execution of each step"
+            },
+            {
+                onShow: viewHome,
+                smartPlacement: true,
+                element: "#output-select",
+                title: "Select Output Type",
+                content: "Change the output type here with the options (HEX - Base 8, DEC - Base 10, ASCII - Base 16) . This by default is set to HEX. ",
+            },
+            {
+                onShow: viewDatapath,
+                smartPlacement: true,
+                element: "#datapath",
+                title: "Datapath",
+                content: "The datapath visualises how the simulator works by illustrating how micro-instructions are performed on the CPU."
+            },
+            {
+                onShow: viewDatapath,
+                smartPlacement: true,
+                backdrop: true,
+                element: "#datapath-status-bar",
+                title: "Status bar",
+                content: "Same as one shown in home screen: Shows you current status: also shows error messages"
+            }
+            ]});
+        // Initialize the tour
+        tour.init();
+
+        // Start the tour
+        tour.start();
     }
-        //Crude way of rerunning tour 
-        // Clears localStorage variable, then reloads page
-        $( "#starttour" ).click(function() {
-            window.localStorage.removeItem('tour_current_step'); //remove tour current step var
-            window.localStorage.removeItem('tour_end'); //removes tour variable
-            location.reload(); //reload page
-        });
+    catch(ex) {
+        console.error(ex);
+    }
+
+    // Crude way of rerunning tour
+    // Clears localStorage variable, then reloads page
+    $( "#starttour" ).click(function() {
+        window.localStorage.removeItem('tour_current_step'); //remove tour current step var
+        window.localStorage.removeItem('tour_end'); //removes tour variable
+        location.reload(); //reload page
     });
-
+});

--- a/src/templates/partials/nav.ejs
+++ b/src/templates/partials/nav.ejs
@@ -43,7 +43,9 @@
                         <li><a href="https://mariejssite.wordpress.com/" target="_blank"><span class="fa fa-wordpress"></span> Blog</a></li>
                         <li class="divider"></li>
                         <li><a href="https://gitreports.com/issue/MARIE-js/MARIE.js/" target="_blank"><span class="fa fa-bug"></span> Report an Issue</a></li>
+                        <% if(title == "Home") { %>
                         <li><a id="starttour"><span class="fa fa-ship"></span> Rerun Tour</a></li>
+                        <% } %>
                     </ul>
                 </li>
             </ul>


### PR DESCRIPTION
Resolved #55 

Known bugs:
* Hovering first set of RTL operations doesn't highlight the first instruction that is being executed (as `sim.current()` returns undefined. It works for the second instruction that is being executed and onwards.
* Performance degrades perhaps due to the expanding number of RTL micro-instructions added to DOM.  This pull request makes it slightly worse due to the fact that it now has to handle divs (which is used for highlighting the link between instruction and sequence of micro-instructions upon hovering the element)