### PR TITLE
slight improvements to ui; fixed some bugs

### DIFF
--- a/src/js/autocomplete.js
+++ b/src/js/autocomplete.js
@@ -6,13 +6,17 @@ function getCompletions(editor) {
     var cursor = editor.getCursor();
     var line = editor.getLine(cursor.line);
 
+    var containsForwardSlash = line.indexOf("/") >= 0;
+
     var end = cursor.ch;
     var start = end;
 
+    // move start backwards until it finds a space in the previous character
     while (line.charAt(start - 1).match(/[^,\s]/)) {
         start--;
     }
 
+    // if the cursor is in front of a space, return nothing
     if (start == end) {
         return;
     }
@@ -44,7 +48,7 @@ function getCompletions(editor) {
         case ("operator"):
             Array.prototype.push.apply(list, completions.operators.map(function(x) {
                 return {
-                    text: x + (nonOperandOperators.indexOf(x) < 0 ? ' ' : '\n'),
+                    text: x + (nonOperandOperators.indexOf(x) < 0 || containsForwardSlash ? ' ' : '\n'),
                     className: "completion-operator"
                 };
             }));
@@ -74,12 +78,12 @@ function getCompletions(editor) {
     list = list.filter(function(completion) {
         var x = completion.text.toLowerCase();
         var y = line.substring(start, end).toLowerCase();
-        return x != y && x.indexOf(y) === 0;
+        return x.trim() != y.trim() && x.indexOf(y) === 0;
     });
 
     return {
         list: list,
         from: from,
-        to: to,
+        to: to
     };
 }

--- a/src/js/interface.js
+++ b/src/js/interface.js
@@ -810,13 +810,13 @@ window.addEventListener("load", function() {
                     currentInstructionRegisterLog.classList.add("finished-instruction");
                 }
 
-                var currentInstruction = sim.current();
+                var currentInstruction = sim.memory[sim.pc];
 
                 currentInstructionRegisterLog = document.createElement("div");
                 currentInstructionRegisterLog.classList.add("instruction-register-log");
 
                 if(currentInstruction && typeof currentInstruction.line !== "undefined") {
-                    currentInstructionRegisterLog.dataset.currentLine = currentInstruction.line;
+                    currentInstructionRegisterLog.dataset.currentLine = currentInstruction.line - 1;
                 }
 
                 registerLog.appendChild(currentInstructionRegisterLog);
@@ -1035,10 +1035,10 @@ window.addEventListener("load", function() {
         }
         if(autoSave) {
             $('#saved-status').text("Autosaved file");
-            console.log("Autosaved file");
+            console.log("Autosaved file", (new Date()).toString());
         } else {
             $('#saved-status').text("Saved file");
-            console.log("Saved file");
+            console.log("Saved file", (new Date()).toString());
         }
     }
 

--- a/src/templates/index.ejs
+++ b/src/templates/index.ejs
@@ -121,7 +121,7 @@
         </div>
 
         <!-- newFile Modal -->
-        <div class="modal fade" id="newfoldermodal" role="dialog">
+        <div class="modal fade " id="newfoldermodal" role="dialog" data-keyboard="true" tabindex="-1">
             <div class="modal-dialog">
                 <!-- Modal content-->
                 <div class="modal-content">
@@ -142,7 +142,7 @@
         <input type="file" id="fileInput" accept=".mas,.txt">
 
         <!-- Preferences Modal -->
-        <div class="modal fade" id="prefs-modal" role="dialog">
+        <div class="modal fade" id="prefs-modal" role="dialog" data-keyboard="true" tabindex="-1">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">

--- a/src/templates/partials/nav.ejs
+++ b/src/templates/partials/nav.ejs
@@ -12,7 +12,7 @@
                     <span class="caret"></span></a>
                     <ul class="dropdown-menu">
                         <li><a id="clear"><span class="fa fa-file-o"></span> New...</a></li>
-                        <li><a id="save"><span class="fa fa-save"></span> Save</a></li>
+                        <li><a id="save"><span class="fa fa-save"></span> Save  | Ctrl+S</a></li>
                         <li class="divider"></li>
                         <li><a id="upload"><span class="fa fa-folder-open-o"></span>  Upload...</a></li>
                         <li><a id="download"><span class="fa fa-download"></span> Download</a></li>
@@ -32,7 +32,7 @@
                     <a class="dropdown-toggle" data-toggle="dropdown"><span class="fa fa-eye"></span> View
                     <span class="caret"></span></a>
                     <ul class="dropdown-menu">
-                        <li><a id="dpath-menu"><span id="datapath-tick" class="fa fa-check fa-pull-right"></span> Datapath</a></li>
+                        <li><a id="dpath-menu"><span class="fa fa-server"></span> Datapath <span id="datapath-tick" class="fa fa-check fa-pull-right"></span></a></li>
                     </ul>
                 </li>
                 <% } %>


### PR DESCRIPTION
- autocomplete does not insert a new line if there is a forward slash (used for commenting)
- fixed bug with autocomplete not detecting complete tokens
- added datapath icon in menu
- added " | Ctrl+S" to `File -> Save` menu item
- fixed bug with link b/w RTL and instruction that fails to highlight the first few instructions
- modals can now be dismissed by using the "Esc" key (although it's a bit annoying that it dismisses even though an input element is in focus)
- console logs for saving files now has a a datetime stamp on them