### PR TITLE
v0.7.17 Patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/MARIE-js/MARIE.js.svg?branch=master)](https://travis-ci.org/MARIE-js/MARIE.js) [![devDependency Status](https://david-dm.org/marie-js/MARIE.js/dev-status.svg)](https://david-dm.org/marie-js/MARIE.js#info=devDependencies) [![Built with Grunt](https://cdn.gruntjs.com/builtwith.svg)](http://gruntjs.com/) [![npm version](https://badge.fury.io/js/npm.svg)](https://badge.fury.io/js/npm)
 ==============
-Current version: `0.7.15`
+Current version: `0.7.17`
 
 MARIE.js is an implementation of a simulator for a 'Machine Architecture that is Really Intuitive and Easy'
 from [The Essentials of Computer Organization and Architecture](https://books.google.com.au/books/about/The_Essentials_of_Computer_Organization.html?id=3kQoAwAAQBAJ&redir_esc=y) (Linda Null, Julia Lobur) in JavaScript.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "MARIE.js",
-  "version": "0.7.15",
+  "version": "0.7.17",
   "description": "MARIE.js is an implementation of a simulator for a 'Machine Architecture that is Really Intuitive and Easy' from The Essentials of Computer Organization and Architecture (Linda Null, Julia Lobur) in JavaScript.",
   "main": "index.js",
   "scripts": {

--- a/src/js/interface.js
+++ b/src/js/interface.js
@@ -58,10 +58,8 @@ window.addEventListener("load", function() {
             autosave = localStorage.getItem("autosave"),
             minDelay = localStorage.getItem("min-delay"),
             maxDelay = localStorage.getItem("max-delay"),
-            binaryStringGroupLength = localStorage.getItem("binaryStringGroup-Length"),
-            defaultInputMode = localStorage.getItem("defaultInputMode-value"),
-            defaultOutputMode = localStorage.getItem("defaultOutputMode-value"),
-            minDatapathDelay = localStorage.getItem("min-datapath-delay");
+            binaryStringGroupLength = localStorage.getItem("binaryStringGroup-Length");
+        var minDatapathDelay = localStorage.getItem("min-datapath-delay");
 
         if(["false", "true"].indexOf(autocomplete) >= 0) {
             prefs.autocomplete = autocomplete === "true";
@@ -85,14 +83,6 @@ window.addEventListener("load", function() {
 
         if(!isNaN(parseInt(minDatapathDelay))) {
             prefs.minDatapathDelay = parseInt(minDatapathDelay);
-        }
-
-        if(!isNaN(parseInt(defaultInputMode))) {
-            prefs.defaultInputMode = defaultInputMode;
-        }
-
-        if(!isNaN(parseInt(defaultOutputMode))) {
-            prefs.defaultOutputMode = defaultOutputMode;
         }
 
         rangeDelay.min = prefs.minDelay;
@@ -1020,7 +1010,7 @@ window.addEventListener("load", function() {
             run();
         }
     }
-
+    getPrefs();
     rangeDelay.addEventListener("change", updateRangeDelay);
 
     restartButton.addEventListener("click", function() {
@@ -1125,8 +1115,8 @@ window.addEventListener("load", function() {
         $("#max-delay").val(prefs.maxDelay);
         $("#min-datapath-delay").val(prefs.minDatapathDelay);
         $("#bstringLength").val(prefs.binaryStringGroupLength);
-        $("#defaultInputMode").val(localStorage.getItem("defaultInputMode-value"));
-        $("#defaultOutputMode").val(localStorage.getItem("defaultOutputMode-value"));
+        $("#defaultInputModeSelect").val(localStorage.getItem("defaultInputMode-value"));
+        $("#defaultOutputModeSelect").val(localStorage.getItem("defaultOutputMode-value"));
         $("#prefs-modal").modal("show");
     });
 
@@ -1142,10 +1132,12 @@ window.addEventListener("load", function() {
         $("#save-changes").prop("disabled", false);
     });
     
-    $("#bstringLength,#defaultOutputMode,#defaultInputMode").change(function(){
+    $("#bstringLength,#defaultOutputModeSelect,#defaultInputModeSelect").change(function(){
         $("#save-changes").prop("disabled", false);
     });
-    $("#defaultOutputMode").val(prefs.defaultOutputMode);
+
+    $("#output-select").val(localStorage.getItem("defaultOutputMode-value"));
+
     $("#save-changes").click(function() {
         var autocomplete = $("#autocomplete").prop("checked"),
             autosave = $("#autosave").prop("checked");
@@ -1153,8 +1145,8 @@ window.addEventListener("load", function() {
         var minDelay = parseInt($("#min-delay").val());
         var maxDelay = parseInt($("#max-delay").val());
         var stringLength = parseInt($("#bstringLength").val());
-        var defaultInputMode = $("#defaultInputMode").val();
-        var defaultOutputMode = $("#defaultOutputMode").val();
+        var defaultInputMode = $("#defaultInputModeSelect").val();
+        var defaultOutputMode = $("#defaultOutputModeSelect").val();
         if(isNaN(minDelay) || isNaN(maxDelay) || minDelay >= maxDelay || minDelay < 0 || maxDelay < 0) {
             $("#prefs-invalid-input-error").show();
             return;
@@ -1180,7 +1172,6 @@ window.addEventListener("load", function() {
         $("#prefs-modal").modal("hide");
     });
 
-    $("#output-select").val(localStorage.getItem("defaultOutputMode-value"));
     $("#set-to-defaults").click(function() {
         prefs = $.extend(defaultPrefs);
         setPrefs();

--- a/src/templates/index.ejs
+++ b/src/templates/index.ejs
@@ -210,7 +210,7 @@
                             <tr>
                                 <td>Default Input Mode:</td>
                                 <td class="prefs-row">
-                                    <select id="defaultInputMode" style="width: 50%;text-align: right">
+                                    <select id="defaultInputModeSelect" style="width: 50%;text-align: right">
                                         <option value="HEX">HEX</option>
                                         <option value="DEC">DEC</option>
                                         <option value="ASCII">UNICODE</option>
@@ -221,7 +221,7 @@
                             <tr>
                                 <td>Default Output Mode:</td>
                                 <td class="prefs-row">
-                                    <select id="defaultOutputMode" style="width: 50%;text-align: right">
+                                    <select id="defaultOutputModeSelect" style="width: 50%;text-align: right">
                                         <option value="HEX">HEX</option>
                                         <option value="DEC">DEC</option>
                                         <option value="ASCII">UNICODE</option>


### PR DESCRIPTION
 - this update fixes the bugs which are found within `v0.7.15`, bugs fixed include
   - upon opening MARIE.js for first time, `#output-select` displays empty or `NaN` value
   - upon saving Default I/O Values, values aren't displayed properly upon refresh
   - fixed some problems with loading default values maybe use `prefs.defaultInputMode.toString()`?
