### PR TITLE
[UI] Make collapsed navbar hamburger menu visible

### DIFF
--- a/src/css/plain.css
+++ b/src/css/plain.css
@@ -517,7 +517,3 @@ codeblock {
   margin-top: 5px;
   margin-right: 0px;
 }
-
-span.icon-bar{
-    background-color: black;
-}

--- a/src/css/plain.css
+++ b/src/css/plain.css
@@ -517,3 +517,7 @@ codeblock {
   margin-top: 5px;
   margin-right: 0px;
 }
+
+span.icon-bar{
+    background-color: black;
+}

--- a/src/css/styleDark.css
+++ b/src/css/styleDark.css
@@ -260,5 +260,9 @@ button[disabled=disabled], button:disabled {
 }
 
 .sr-only {
-  color: white'
+  color: white;
+}
+
+span.icon-bar {
+    background-color: white;
 }

--- a/src/css/styleLight.css
+++ b/src/css/styleLight.css
@@ -555,3 +555,7 @@ codeblock {
 #assemblyCodeLabel {
   color:black;
 }
+
+span.icon-bar {
+    background-color: black;
+}


### PR DESCRIPTION
Currently when you collapse the navbar the hamburger lines are the same colour as the navbar. This makes it invisible to the user, adding this css somewhere (or something similar) will set those lines to black so the user can see.

TL;DR this is current UI:
![screen shot 2016-09-21 at 2 26 46 pm](https://cloud.githubusercontent.com/assets/12482943/18697737/7bb271be-8007-11e6-875b-edf49f5dda73.png)

And this is new UI:
![screen shot 2016-09-21 at 2 26 54 pm](https://cloud.githubusercontent.com/assets/12482943/18697739/82a58e70-8007-11e6-8f4b-6630523d11a7.png)
