### PR TITLE
Add ability to link code

### DIFF
--- a/src/js/interface.js
+++ b/src/js/interface.js
@@ -197,6 +197,29 @@ window.addEventListener("load", function() {
 
     getPrefs();
 
+    $("#overridebtn").click(function() {
+        restoreUrlHashCode();
+        $("#copyOverrideModal").modal("hide");
+    });
+    $("#canceloverridebtn").click(function() {
+        $("#copyOverrideModal").modal("hide");
+    });
+    function handleLoadingUrlCode() {
+        if (window.location.hash.startsWith("#code=")) {
+            if (localStorage.getItem("marie-program")) {
+                $("#copyOverrideModal").modal("show");
+            } else {
+                restoreUrlHashCode();
+            }
+        }
+    }
+    function restoreUrlHashCode() {
+        loadContents(decodeURI(window.location.hash.replace("#code=", "")));
+        $("#saved-status").text("Loaded linked code");
+        window.location.hash = ""; // keep clean
+    }
+
+    handleLoadingUrlCode();
     textArea.value = localStorage.getItem("marie-program") || "";
 
     if(textArea.value !== "") {
@@ -1358,6 +1381,28 @@ window.addEventListener("load", function() {
         return;
     };
 
+    $("#copylink").click(function() {
+        var copyCode = programCodeMirror.getValue();
+        if (!copyCode) {
+            return;
+        }
+        var copyUrl = (window.location.origin !== "null" // local origin
+            ? window.location.origin + window.location.pathname
+            : "https://marie.js.org/"
+        ) + "#code=" + encodeURI(copyCode);
+
+        // copying stuff
+        var el = document.createElement("textarea");
+        el.value = copyUrl;
+        el.setAttribute("readonly", "");
+        el.style = { display: "none" };
+        document.body.appendChild(el);
+        el.select();
+        document.execCommand("copy");
+        document.body.removeChild(el);
+        $("#saved-status").text("File copied as link");
+    });
+
     uploadButton.addEventListener("click", function() {
         fileInput.click();
     });
@@ -1602,6 +1647,7 @@ window.addEventListener("load", function() {
 
     $(window).on('hashchange', function() {
         handleDatapathUI();
+        handleLoadingUrlCode();
     });
 
     $("body").removeClass("preload");

--- a/src/templates/index.ejs
+++ b/src/templates/index.ejs
@@ -416,6 +416,25 @@
                         </div>
                     </div>
 
+        <!-- Copy Override Modal -->
+        <div class="modal fade" id="copyOverrideModal" role="dialog" tabindex="-1">
+            <div class="modal-dialog">
+                <!-- Modal content-->
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h4 class="modal-title">MARIE.js | <span class="fa fa-copy"></span> Linked Code</h4>
+                    </div>
+                    <div class="modal-body">
+                        <p>Your code will be overridden with Linked Code. Continue?</p>
+                    </div>
+                    <div class="modal-footer">
+                        <button id="canceloverridebtn" type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                        <button id="overridebtn" type="button" class="btn btn-danger" data-dismiss="modal">Yes</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <!-- ToU Agreement Modal -->
             <div class="modal fade" id="tosModal" role="dialog" data-backdrop="static">
                 <div class="modal-dialog">

--- a/src/templates/partials/nav.ejs
+++ b/src/templates/partials/nav.ejs
@@ -26,6 +26,8 @@
               <li class="divider"></li>
               <li><a id="upload"><span class="fa fa-folder-open-o"></span>  Upload...</a></li>
               <li><a id="download"><span class="fa fa-download"></span> Download</a></li>
+              <li class="divider"></li>
+              <li><a id="copylink"><span class="fa fa-copy"></span> Copy link</a></li>
           </ul>
       </li>
       <li class="dropdown">


### PR DESCRIPTION
Similar to how Python Tutor has a code linking feature, where you can link code to visualise by linking with `#code=`, I have implemented this feature for MARIE.js.

Could be a useful feature for lecturers to easily link to code in the simulator, and/or other sharing code fragments purposes. Combined with a link shortener, it avoids the hassle of copying plain text between slides/people or having to download a file first.