### PR TITLE
Add UTF-16 output capabilities

### DIFF
--- a/src/code/unicode.mas
+++ b/src/code/unicode.mas
@@ -1,0 +1,63 @@
+/ Unicode (UTF-16BE) Demo
+/ by the MARIE.js Team
+/ Copyright (C) 2020. Licensed under the MIT License
+
+LOOP, Load PTR
+/ output word
+LoadI PTR
+Output
+
+/ increment pointer
+Load PTR
+Add ONE
+Store PTR
+
+/ increment counter
+Load CTR
+Add ONE
+Store CTR
+
+/ check whether all words have been processed and halt if so
+Subt WORDS
+Skipcond 400
+Jump LOOP
+Halt
+
+ONE, DEC 1
+CTR, DEC 0
+WORDS, DEC 19
+
+/ initialize pointer to words
+PTR, ADR S
+
+/ ouput data
+/ "Hello World!"
+S, HEX 48
+HEX 45 
+HEX 4C
+HEX 4C
+HEX 4F
+HEX 20
+HEX 57
+HEX 4F
+HEX 52
+HEX 4C
+HEX 44
+HEX 21
+
+/ Smiley (outside of the Basic Multilingual Plane)
+HEX D83D
+HEX DE42
+
+/ Byte Order Mark, big-endian (ignored)
+HEX FEFF
+
+/ Byte Order Mark, little-endian (ignored)
+HEX FFFE
+
+/ Inverted Smiley (outside of the BMP)
+HEX D83D
+HEX DE43
+
+/ Copyright Sign (inside the BMP)
+HEX A9

--- a/src/js/interface.js
+++ b/src/js/interface.js
@@ -473,7 +473,7 @@ window.addEventListener("load", function() {
                 }
                 break;
             case BIN:
-                return document.createTextNode(Utility.uintToBinGroup(value, 16, prefs.binaryStringGroupLength));
+                return document.createTextNode(Utility.intToBinGroup(value, 16, prefs.binaryStringGroupLength));
             default:
                 return document.createTextNode("Invalid output type.");
         }

--- a/src/js/interface.js
+++ b/src/js/interface.js
@@ -447,6 +447,13 @@ window.addEventListener("load", function() {
     }
 
     function convertOutput(value) {
+        // Unicode UTF-16BE characters outside the Basic Multilingual Plane
+        // are encoded using a 2-word sequence called a surrogate pair.
+        // Assuming network byte order, i.e. a big-endian encoding,
+        // the high surrogate comes first in the output stream,
+        // and then comes the  low surrogate.
+        // Since we assume network byte order, we can legally ignore Byte Order
+        // Markers according to the Unicode standard.
         if( convertOutput.highSurrogate === undefined ) {
             convertOutput.highSurrogate = 0;
         }
@@ -458,19 +465,50 @@ window.addEventListener("load", function() {
             case UNICODE:
                 if (value===10) {
                   return document.createElement("br");
-                } else {
-                  if(value>=-10240 && value<=-9217) {
-                    convertOutput.highSurrogate = value;
-                    return document.createTextNode("");
-                  }
-                  if(convertOutput.highSurrogate!=0 &&
-                     value>=-9216 && value<=-8193) {
-                       var output = String.fromCharCode(convertOutput.highSurrogate, value);
-                       convertOutput.highSurrogate = 0;
-                       return document.createTextNode(output);
-                     }
-                  return document.createTextNode(String.fromCharCode(value));
                 }
+                if(value >= -10240 && value <= -9217) {
+                  // start of a valid UTF-16BE surrogate pair
+                  // high surrogates are in the range of 0xD800 - 0xDBFF
+                  // converted to 16-bit two's complement integers,
+                  // this yields the negative number range from
+                  // -10240 to -9217
+                  convertOutput.highSurrogate = value;
+                  return null;
+                }
+                if (convertOutput.highSurrogate === 0 &&
+                    value >= -9216 && value <= -8193) {
+                  // low surrogate without high surrogate
+                  // invalid UTF-16BE sequence
+                  // low surrogates are in the range of 0xDC00 - 0xDFFF
+                  // converted to 16-bit two's complement integers,
+                  // this yields the negative number range from
+                  // -9216 to -8193
+                  return null;
+                }
+                if (convertOutput.highSurrogate != 0 &&
+                    value >= -9216 && value <= -8193) {
+                  // valid UTF-16BE surrogate pair
+                  var output = String.fromCharCode(convertOutput.highSurrogate, value);
+                  convertOutput.highSurrogate = 0;
+                  return document.createTextNode(output);
+                }
+                if (convertOutput.highSurrogate != 0 &&
+                    !(value >= -9216 && value <= -8193)) {
+                  // high surrogate without low surrogate
+                  // invalid UTF-16BE sequence
+                  convertOutput.highSurrogate = 0;
+                  return null;
+                }
+                if (value === -2 || value === -257) {
+                  // Byte Order Mark (0xFFFE or 0xFEFF), ignore
+                  // 0xFFFE converted to 16-bit two's complement integer
+                  // is -2,
+                  // 0xFEFF converted to 16-bit two's complement integer
+                  // is -257
+                  return null;
+                }
+                // character is in the Basic Multilingual Plane
+                return document.createTextNode(String.fromCharCode(value));
                 break;
             case BIN:
                 return document.createTextNode(Utility.intToBinGroup(value, 16, prefs.binaryStringGroupLength));
@@ -485,7 +523,10 @@ window.addEventListener("load", function() {
         }
 
         for(var i = 0; i < outputList.length; i++) {
-            outputLog.appendChild(convertOutput(outputList[i]));
+            var element = convertOutput(outputList[i]);
+            if (element != null) {
+              outputLog.appendChild(element);
+            }
             if (outputType!==UNICODE) {
               outputLog.appendChild(document.createElement("br"));
             }
@@ -801,8 +842,10 @@ window.addEventListener("load", function() {
         var shouldScrollToBottomOutputLog = outputLog.getAttribute("data-stick-to-bottom") == "true";
 
         outputList.push(value);
-
-        outputLog.appendChild(convertOutput(value));
+        var element = convertOutput(value);
+        if (element != null) {
+          outputLog.appendChild(element);
+        }
         if (outputType!==UNICODE) {
           outputLog.appendChild(document.createElement("br"));
         }

--- a/src/js/interface.js
+++ b/src/js/interface.js
@@ -447,6 +447,9 @@ window.addEventListener("load", function() {
     }
 
     function convertOutput(value) {
+        if( convertOutput.highSurrogate === undefined ) {
+            convertOutput.highSurrogate = 0;
+        }
         switch(outputType) {
             case HEX:
                 return document.createTextNode(Utility.hex(value));
@@ -456,6 +459,16 @@ window.addEventListener("load", function() {
                 if (value===10) {
                   return document.createElement("br");
                 } else {
+                  if(value>=-10240 && value<=-9217) {
+                    convertOutput.highSurrogate = value;
+                    return document.createTextNode("");
+                  }
+                  if(convertOutput.highSurrogate!=0 &&
+                     value>=-9216 && value<=-8193) {
+                       var output = String.fromCharCode(convertOutput.highSurrogate, value);
+                       convertOutput.highSurrogate = 0;
+                       return document.createTextNode(output);
+                     }
                   return document.createTextNode(String.fromCharCode(value));
                 }
                 break;

--- a/src/js/utility.js
+++ b/src/js/utility.js
@@ -34,6 +34,27 @@ var Utility = {};
         return binArray;
     };
 
+    /**
+     * Converts a signed integer in *size*-bit twos-complement format
+     * into an array of binary numbers.
+     * @memberof Utility
+     *
+     * @param {Number} num - the signed integer to be converted.
+     * @param {Number} size - size of the signed integer.
+     * @returns {Array} the binary array representation of signed integer.
+     */
+    Utility.intToBinArray = function(num, size) {
+        var binArray = [];
+        console.log(size);
+        for(var i=0; i<size; i++){
+            binArray.push(num & 1);
+            num >>= 1;
+        }
+
+        binArray.reverse();
+
+        return binArray;
+    };
 
     /**
      * Converts an unsigned integer into an array of
@@ -61,6 +82,31 @@ var Utility = {};
         return binString;
     };
 
+    /**
+     * Converts a signed integer in *size*-bit twos complement format
+     * into an array of binary numbers, and then converts into a bit string
+     * with even spacing between each group of binary digits.
+     * @memberof Utility
+     *
+     * @param {Number} num - The unsigned integer to be converted.
+     * @param {Number} size - Size of the signed integer.
+     * @param {Number} bitSize - The length of each bit group.
+     * @returns {String} The binary array representation of signed integer.
+     */
+    Utility.intToBinGroup = function(num, size, bitSize) {
+        var binArray = Utility.intToBinArray(num, size);
+        var binString = "";
+
+        for (var i = 0; i < size; i++) {
+            binString += binArray[i];
+
+            if(i % bitSize == bitSize - 1){
+                binString += " ";
+            }
+        }
+
+        return binString;
+    };
 
     /**
      * Converts signed integer into unsigned integer.

--- a/src/js/utility.js
+++ b/src/js/utility.js
@@ -35,7 +35,7 @@ var Utility = {};
     };
 
     /**
-     * Converts a signed integer in *size*-bit twos-complement format
+     * Converts a signed integer in *size*-bit two's-complement format
      * into an array of binary numbers.
      * @memberof Utility
      *
@@ -45,7 +45,6 @@ var Utility = {};
      */
     Utility.intToBinArray = function(num, size) {
         var binArray = [];
-        console.log(size);
         for(var i=0; i<size; i++){
             binArray.push(num & 1);
             num >>= 1;
@@ -83,7 +82,7 @@ var Utility = {};
     };
 
     /**
-     * Converts a signed integer in *size*-bit twos complement format
+     * Converts a signed integer in *size*-bit two's complement format
      * into an array of binary numbers, and then converts into a bit string
      * with even spacing between each group of binary digits.
      * @memberof Utility

--- a/src/templates/index.ejs
+++ b/src/templates/index.ejs
@@ -44,7 +44,7 @@
                                       <select id="output-select" class="output-type">
                                           <option>HEX</option>
                                           <option>DEC</option>
-                                          <option>UNICODE</option>
+                                          <option>UNICODE (UTF-16BE)</option>
                                           <option>BIN</option>
                                       </select>
                                       <hr>
@@ -70,7 +70,7 @@
                                       <select id="input-list-select" class="output-type">
                                           <option>HEX</option>
                                           <option>DEC</option>
-                                          <option>UNICODE</option>
+                                          <option>UNICODE (UTF-16BE)</option>
                                           <option>BIN</option>
                                       </select>
                                   </div>

--- a/src/templates/partials/nav.ejs
+++ b/src/templates/partials/nav.ejs
@@ -37,6 +37,7 @@
               <li><a href="./?addition"><span class="fa fa-plus"></span> Addition</a></li>
               <li><a href="./?multiply"><span class="fa fa-times"></span> Multiply</a></li>
               <li><a href="./?quicksort"><span class="fa fa-sort"></span> Quicksort</a></li>
+              <li><a href="./?unicode"><span class="fa fa-font"></span> Unicode</a></li>
           </ul>
       </li>
       <li class="dropdown">


### PR DESCRIPTION
Referring to issue #288:

When set to Unicode, the output conversion function now can handle
characters outside the Basic Multilingual Plane, using UTF-16.
The output conversion function will detect whether a value passed in
is a high surrogate value and save it in a static variable.
If the next character is a correct low surrogate, the function will
return the correct unicode character, otherwise it will discard the
input.

The following code should output a smiley 🙂:
```
Load H
Output
Load L
Output
Halt
H, HEX D83D
L, HEX DE42
```