### PR TITLE
fix syntax highlight of labels references

### DIFF
--- a/src/js/syntax.js
+++ b/src/js/syntax.js
@@ -15,7 +15,7 @@ CodeMirror.defineSimpleMode("marie", {
     operand: [
         {regex: /(?:org|dec|oct|hex)\b/i, token: "atom", next: "literal"}, // Literal
         {regex: /\d[0-9a-f]*\b/i, token: "variable-3", next: "start"}, // Address
-        {regex: /[0-9a-z]+\b/i, token: "variable-2", next: "start"}, // Reference
+        {regex: /[0-9a-z_\.]+\b/i, token: "variable-2", next: "start"}, // Reference
     ],
     literal: [
         {regex: /[0-9a-f]+/i, token: "number", next: "start"} // Number

--- a/src/js/syntax.js
+++ b/src/js/syntax.js
@@ -15,7 +15,7 @@ CodeMirror.defineSimpleMode("marie", {
     operand: [
         {regex: /(?:org|dec|oct|hex)\b/i, token: "atom", next: "literal"}, // Literal
         {regex: /\d[0-9a-f]*\b/i, token: "variable-3", next: "start"}, // Address
-        {regex: /[0-9a-z_\.]+\b/i, token: "variable-2", next: "start"}, // Reference
+        {regex: /[^\d,\/\s][^,\/\s]*\b/i, token: "variable-2", next: "start"}, // Reference
     ],
     literal: [
         {regex: /[0-9a-f]+/i, token: "number", next: "start"} // Number


### PR DESCRIPTION
Image attached is an example of the color changes in a valid MARIE.js program

Note: I only added underscores and periods as they make up reasonable label names in English. For example, label names in Chinese / Arabic are also accepted by MARIE but are unnecessarily complicated to deal with in Regex.

![Syntaxhighlight_before_after](https://user-images.githubusercontent.com/7828692/113403039-9bbce900-93d8-11eb-9617-8a539b3a82b1.png)