### PR TITLE
[P] fixing unicode input mode bug on input list

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -242,10 +242,10 @@
                                   <div id="input-list-type">
                                       <b>INPUT MODE: </b>
                                       <select id="input-list-select" class="output-type">
-                                          <option>HEX</option>
-                                          <option>DEC</option>
-                                          <option>UNICODE (UTF-16BE)</option>
-                                          <option>BIN</option>
+                                          <option value="HEX">HEX</option>
+                                          <option value="DEC">DEC</option>
+                                          <option value="UNICODE">UNICODE (UTF-16BE)</option>
+                                          <option value="BIN">BIN</option>
                                       </select>
                                   </div>
                                   <hr>

--- a/src/templates/index.ejs
+++ b/src/templates/index.ejs
@@ -68,10 +68,10 @@
                                   <div id="input-list-type">
                                       <b>INPUT MODE: </b>
                                       <select id="input-list-select" class="output-type">
-                                          <option>HEX</option>
-                                          <option>DEC</option>
-                                          <option>UNICODE (UTF-16BE)</option>
-                                          <option>BIN</option>
+                                          <option value="HEX">HEX</option>
+                                          <option value="DEC">DEC</option>
+                                          <option value="UNICODE">UNICODE (UTF-16BE)</option>
+                                          <option value="BIN">BIN</option>
                                       </select>
                                   </div>
                                   <hr>


### PR DESCRIPTION
Reading unicode values from Input List would fail, falling back to the Input Value modal.

Turns out it happened because of a mismatch between the option text and the expected value on `getInputFromInputList`.

<img width="804" alt="image" src="https://github.com/MARIE-js/MARIE.js/assets/29143487/4b976c69-f51a-471d-818a-cb43a3866b0a">
