### PR TITLE
Allow integer overflow

### DIFF
--- a/doc/marie.js.html
+++ b/doc/marie.js.html
@@ -426,9 +426,11 @@ var MarieSim,
         }
 
 
-        //this fixes the bug, where the user tries to go beyond HEX-FFFF
-        if(this[target] > 32767 || this[target] &lt; -32768){
-            throw new MarieSimError("OverFlow Error","the value " + this[target].toString() + "  is beyond the calculable range");
+        if(this[target] > 32767) {
+            this[target] -= 65536;
+        }
+        else if(this[target] < -32768) {
+            this[target] += 65536
         }
 
 

--- a/src/js/marie.js
+++ b/src/js/marie.js
@@ -398,9 +398,11 @@ var MarieSim,
         }
 
 
-        //this fixes the bug, where the user tries to go beyond HEX-FFFF
-        if(this[target] > 32767 || this[target] < -32768){
-            throw new MarieSimError("OverFlow Error","the value " + this[target].toString() + "  is beyond the calculable range");
+        if(this[target] > 32767) {
+            this[target] -= 65536;
+        }
+        else if(this[target] < -32768) {
+            this[target] += 65536
         }
 
 


### PR DESCRIPTION
Adding two numbers with a sum outside the range of representable numbers in two's complement results in an error, when it would be more accurate and useful to allow the number to overflow and change sign.