### PR TITLE
Add small backwards-compatible features to language, improve editing experience

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "marie-js",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "marie-js",
-			"version": "2.0.0",
+			"version": "2.1.0",
 			"dependencies": {
 				"@codemirror/commands": "^6.8.0",
 				"@codemirror/language": "^6.10.8",
@@ -22,16 +22,16 @@
 			"devDependencies": {
 				"@sveltejs/vite-plugin-svelte": "^5.0.3",
 				"@tsconfig/svelte": "^5.0.4",
-				"@types/lodash": "^4.17.14",
-				"@types/node": "^22.10.10",
-				"prettier": "^3.4.2",
+				"@types/lodash": "^4.17.15",
+				"@types/node": "^22.13.1",
+				"prettier": "^3.5.0",
 				"prettier-plugin-svelte": "^3.3.3",
-				"svelte": "^5.19.3",
+				"svelte": "^5.19.10",
 				"svelte-check": "^4.1.4",
 				"tslib": "^2.8.1",
 				"typescript": "^5.7.3",
-				"vite": "^6.0.11",
-				"vitest": "^3.0.4"
+				"vite": "^6.1.0",
+				"vitest": "^3.0.5"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -923,28 +923,28 @@
 			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
 		},
 		"node_modules/@types/lodash": {
-			"version": "4.17.14",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.14.tgz",
-			"integrity": "sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A==",
+			"version": "4.17.15",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.15.tgz",
+			"integrity": "sha512-w/P33JFeySuhN6JLkysYUK2gEmy9kHHFN7E8ro0tkfmlDOgxBDzWEZ/J8cWA+fHqFevpswDTFZnDx+R9lbL6xw==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "22.10.10",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.10.tgz",
-			"integrity": "sha512-X47y/mPNzxviAGY5TcYPtYL8JsY3kAq2n8fMmKoRCxq/c4v4pyGNCzM2R6+M5/umG4ZfHuT+sgqDYqWc9rJ6ww==",
+			"version": "22.13.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.1.tgz",
+			"integrity": "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==",
 			"dev": true,
 			"dependencies": {
 				"undici-types": "~6.20.0"
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.4.tgz",
-			"integrity": "sha512-Nm5kJmYw6P2BxhJPkO3eKKhGYKRsnqJqf+r0yOGRKpEP+bSCBDsjXgiu1/5QFrnPMEgzfC38ZEjvCFgaNBC0Eg==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.5.tgz",
+			"integrity": "sha512-nNIOqupgZ4v5jWuQx2DSlHLEs7Q4Oh/7AYwNyE+k0UQzG7tSmjPXShUikn1mpNGzYEN2jJbTvLejwShMitovBA==",
 			"dev": true,
 			"dependencies": {
-				"@vitest/spy": "3.0.4",
-				"@vitest/utils": "3.0.4",
+				"@vitest/spy": "3.0.5",
+				"@vitest/utils": "3.0.5",
 				"chai": "^5.1.2",
 				"tinyrainbow": "^2.0.0"
 			},
@@ -953,12 +953,12 @@
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.0.4.tgz",
-			"integrity": "sha512-gEef35vKafJlfQbnyOXZ0Gcr9IBUsMTyTLXsEQwuyYAerpHqvXhzdBnDFuHLpFqth3F7b6BaFr4qV/Cs1ULx5A==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.0.5.tgz",
+			"integrity": "sha512-CLPNBFBIE7x6aEGbIjaQAX03ZZlBMaWwAjBdMkIf/cAn6xzLTiM3zYqO/WAbieEjsAZir6tO71mzeHZoodThvw==",
 			"dev": true,
 			"dependencies": {
-				"@vitest/spy": "3.0.4",
+				"@vitest/spy": "3.0.5",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.17"
 			},
@@ -979,9 +979,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.4.tgz",
-			"integrity": "sha512-ts0fba+dEhK2aC9PFuZ9LTpULHpY/nd6jhAQ5IMU7Gaj7crPCTdCFfgvXxruRBLFS+MLraicCuFXxISEq8C93g==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.5.tgz",
+			"integrity": "sha512-CjUtdmpOcm4RVtB+up8r2vVDLR16Mgm/bYdkGFe3Yj/scRfCpbSi2W/BDSDcFK7ohw8UXvjMbOp9H4fByd/cOA==",
 			"dev": true,
 			"dependencies": {
 				"tinyrainbow": "^2.0.0"
@@ -991,12 +991,12 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.0.4.tgz",
-			"integrity": "sha512-dKHzTQ7n9sExAcWH/0sh1elVgwc7OJ2lMOBrAm73J7AH6Pf9T12Zh3lNE1TETZaqrWFXtLlx3NVrLRb5hCK+iw==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.0.5.tgz",
+			"integrity": "sha512-BAiZFityFexZQi2yN4OX3OkJC6scwRo8EhRB0Z5HIGGgd2q+Nq29LgHU/+ovCtd0fOfXj5ZI6pwdlUmC5bpi8A==",
 			"dev": true,
 			"dependencies": {
-				"@vitest/utils": "3.0.4",
+				"@vitest/utils": "3.0.5",
 				"pathe": "^2.0.2"
 			},
 			"funding": {
@@ -1004,12 +1004,12 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.0.4.tgz",
-			"integrity": "sha512-+p5knMLwIk7lTQkM3NonZ9zBewzVp9EVkVpvNta0/PlFWpiqLaRcF4+33L1it3uRUCh0BGLOaXPPGEjNKfWb4w==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.0.5.tgz",
+			"integrity": "sha512-GJPZYcd7v8QNUJ7vRvLDmRwl+a1fGg4T/54lZXe+UOGy47F9yUfE18hRCtXL5aHN/AONu29NGzIXSVFh9K0feA==",
 			"dev": true,
 			"dependencies": {
-				"@vitest/pretty-format": "3.0.4",
+				"@vitest/pretty-format": "3.0.5",
 				"magic-string": "^0.30.17",
 				"pathe": "^2.0.2"
 			},
@@ -1018,9 +1018,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.0.4.tgz",
-			"integrity": "sha512-sXIMF0oauYyUy2hN49VFTYodzEAu744MmGcPR3ZBsPM20G+1/cSW/n1U+3Yu/zHxX2bIDe1oJASOkml+osTU6Q==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.0.5.tgz",
+			"integrity": "sha512-5fOzHj0WbUNqPK6blI/8VzZdkBlQLnT25knX0r4dbZI9qoZDf3qAdjoMmDcLG5A83W6oUUFJgUd0EYBc2P5xqg==",
 			"dev": true,
 			"dependencies": {
 				"tinyspy": "^3.0.2"
@@ -1030,12 +1030,12 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.4.tgz",
-			"integrity": "sha512-8BqC1ksYsHtbWH+DfpOAKrFw3jl3Uf9J7yeFh85Pz52IWuh1hBBtyfEbRNNZNjl8H8A5yMLH9/t+k7HIKzQcZQ==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.5.tgz",
+			"integrity": "sha512-N9AX0NUoUtVwKwy21JtwzaqR5L5R5A99GAbrHfCCXK1lp593i/3AZAXhSP43wRQuxYsflrdzEfXZFo1reR1Nkg==",
 			"dev": true,
 			"dependencies": {
-				"@vitest/pretty-format": "3.0.4",
+				"@vitest/pretty-format": "3.0.5",
 				"loupe": "^3.1.2",
 				"tinyrainbow": "^2.0.0"
 			},
@@ -1336,9 +1336,9 @@
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"node_modules/loupe": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.2.tgz",
-			"integrity": "sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
+			"integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
 			"dev": true
 		},
 		"node_modules/magic-string": {
@@ -1383,9 +1383,9 @@
 			}
 		},
 		"node_modules/pathe": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.2.tgz",
-			"integrity": "sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
 			"dev": true
 		},
 		"node_modules/pathval": {
@@ -1432,9 +1432,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
-			"integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.0.tgz",
+			"integrity": "sha512-quyMrVt6svPS7CjQ9gKb3GLEX/rl3BCL2oa/QkNcXv4YNVBC9olt3s+H7ukto06q7B1Qz46PbrKLO34PR6vXcA==",
 			"dev": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
@@ -1557,9 +1557,9 @@
 			"integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw=="
 		},
 		"node_modules/svelte": {
-			"version": "5.19.3",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.19.3.tgz",
-			"integrity": "sha512-rb/bkYG9jq67OCWikMvaPnfOobyGn0JizVDwHpdeBtLiNXPMcoA9GTFC3BhptP7xGNquUU8J5GiS7PlGlfDAFA==",
+			"version": "5.19.10",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.19.10.tgz",
+			"integrity": "sha512-7lId+z36IZWzuo0N0oGOStEPi3/Wv1VQEnIzMmDaLDSlJSruKplhhVr+NaZ0Wh7ZILfOjbeU7PbTjqmQQYZF4A==",
 			"dependencies": {
 				"@ampproject/remapping": "^2.3.0",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1676,14 +1676,14 @@
 			"dev": true
 		},
 		"node_modules/vite": {
-			"version": "6.0.11",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-6.0.11.tgz",
-			"integrity": "sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-6.1.0.tgz",
+			"integrity": "sha512-RjjMipCKVoR4hVfPY6GQTgveinjNuyLw+qruksLDvA5ktI1150VmcMBKmQaEWJhg/j6Uaf6dNCNA0AfdzUb/hQ==",
 			"dev": true,
 			"dependencies": {
 				"esbuild": "^0.24.2",
-				"postcss": "^8.4.49",
-				"rollup": "^4.23.0"
+				"postcss": "^8.5.1",
+				"rollup": "^4.30.1"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
@@ -1747,9 +1747,9 @@
 			}
 		},
 		"node_modules/vite-node": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.0.4.tgz",
-			"integrity": "sha512-7JZKEzcYV2Nx3u6rlvN8qdo3QV7Fxyt6hx+CCKz9fbWxdX5IvUOmTWEAxMrWxaiSf7CKGLJQ5rFu8prb/jBjOA==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.0.5.tgz",
+			"integrity": "sha512-02JEJl7SbtwSDJdYS537nU6l+ktdvcREfLksk/NDAqtdKWGqHl+joXzEubHROmS3E6pip+Xgu2tFezMu75jH7A==",
 			"dev": true,
 			"dependencies": {
 				"cac": "^6.7.14",
@@ -1783,18 +1783,18 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.4.tgz",
-			"integrity": "sha512-6XG8oTKy2gnJIFTHP6LD7ExFeNLxiTkK3CfMvT7IfR8IN+BYICCf0lXUQmX7i7JoxUP8QmeP4mTnWXgflu4yjw==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.5.tgz",
+			"integrity": "sha512-4dof+HvqONw9bvsYxtkfUp2uHsTN9bV2CZIi1pWgoFpL1Lld8LA1ka9q/ONSsoScAKG7NVGf2stJTI7XRkXb2Q==",
 			"dev": true,
 			"dependencies": {
-				"@vitest/expect": "3.0.4",
-				"@vitest/mocker": "3.0.4",
-				"@vitest/pretty-format": "^3.0.4",
-				"@vitest/runner": "3.0.4",
-				"@vitest/snapshot": "3.0.4",
-				"@vitest/spy": "3.0.4",
-				"@vitest/utils": "3.0.4",
+				"@vitest/expect": "3.0.5",
+				"@vitest/mocker": "3.0.5",
+				"@vitest/pretty-format": "^3.0.5",
+				"@vitest/runner": "3.0.5",
+				"@vitest/snapshot": "3.0.5",
+				"@vitest/spy": "3.0.5",
+				"@vitest/utils": "3.0.5",
 				"chai": "^5.1.2",
 				"debug": "^4.4.0",
 				"expect-type": "^1.1.0",
@@ -1806,7 +1806,7 @@
 				"tinypool": "^1.0.2",
 				"tinyrainbow": "^2.0.0",
 				"vite": "^5.0.0 || ^6.0.0",
-				"vite-node": "3.0.4",
+				"vite-node": "3.0.5",
 				"why-is-node-running": "^2.3.0"
 			},
 			"bin": {
@@ -1822,8 +1822,8 @@
 				"@edge-runtime/vm": "*",
 				"@types/debug": "^4.1.12",
 				"@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-				"@vitest/browser": "3.0.4",
-				"@vitest/ui": "3.0.4",
+				"@vitest/browser": "3.0.5",
+				"@vitest/ui": "3.0.5",
 				"happy-dom": "*",
 				"jsdom": "*"
 			},

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "marie-js",
 	"private": true,
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",
@@ -15,16 +15,16 @@
 	"devDependencies": {
 		"@sveltejs/vite-plugin-svelte": "^5.0.3",
 		"@tsconfig/svelte": "^5.0.4",
-		"@types/lodash": "^4.17.14",
-		"@types/node": "^22.10.10",
-		"prettier": "^3.4.2",
+		"@types/lodash": "^4.17.15",
+		"@types/node": "^22.13.1",
+		"prettier": "^3.5.0",
 		"prettier-plugin-svelte": "^3.3.3",
-		"svelte": "^5.19.3",
+		"svelte": "^5.19.10",
 		"svelte-check": "^4.1.4",
 		"tslib": "^2.8.1",
 		"typescript": "^5.7.3",
-		"vite": "^6.0.11",
-		"vitest": "^3.0.4"
+		"vite": "^6.1.0",
+		"vitest": "^3.0.5"
 	},
 	"dependencies": {
 		"@codemirror/commands": "^6.8.0",

--- a/public/examples/quicksort.mas
+++ b/public/examples/quicksort.mas
@@ -7,542 +7,542 @@
 / Next input is the list of numbers to be sorted
 
 /Note: the comments assume for a basic understanding for the quicksort algorithm
-						Jump 		Begin 	/Skips the variables defined below
+				Jump 		Begin 			/Skips the variables defined below
 
 /Variables for the list creation
-Size,				DEC 		0
+Size,			DEC 		0
 Counter,		DEC 		0
 
 /Numeric variables for basic addition
-One,				DEC	 		1
-Two,				DEC 		2
-Four,				DEC 		4
+One,			DEC	 		1
+Two,			DEC 		2
+Four,			DEC 		4
 MinOne,			DEC 		-1
 
 /List management
-ListAddress,		HEX 		330		/Stores the starting address of the list
-ListAddPointer,	HEX 		330		/Points to the current item of the list
-ListAllocation,	HEX 		300		/Stores the addresses of the start addresses
-															/of all lists created
+ListAddress,	HEX 		330				/Stores the starting address of the list
+ListAddPointer,	HEX 		330				/Points to the current item of the list
+ListAllocation,	HEX 		300				/Stores the addresses of the start addresses
+											/of all lists created
 /Stack management
-StackPointer,		HEX 		700		/Stack's beginning address
+StackPointer,	HEX 		700				/Stack's beginning address
 
 /Temporary labels
-t0,					DEC 		0 		/Used to store various (temporary) values
-t1,					DEC 		0
-temp, 			DEC 		0		/This is used specifically to load/store indirectly multiple times
+t0,				DEC 		0 				/Used to store various (temporary) values
+t1,				DEC 		0
+temp, 			DEC 		0				/This is used specifically to load/store indirectly multiple times
 
 				/The main program reads a list then sorts it:
-                /First the user is prompted for a size, N, of a list to create, and will prompt N times, each
-                /time appending the value entered to the list
+				/First the user is prompted for a size, N, of a list to create, and will prompt N times, each
+				/time appending the value entered to the list
 Begin,			Input 						/Input size
-						Store		Size 			/Store to both Size and Counter labels
-  					Store 		Counter
+				Store		Size 			/Store to both Size and Counter labels
+				Store 		Counter
 
-    				StoreI 		ListAddress 	/Store size value at the list's starting address
+				StoreI 		ListAddress 	/Store size value at the list's starting address
 
-    				Load 		ListAddress 	/Store the list's starting address as reference
-    				StoreI		ListAllocation
+				Load 		ListAddress 	/Store the list's starting address as reference
+				StoreI		ListAllocation
 
-    				Load 		ListAllocation 	/Move this pointer up (one value), ready to
-    				Add 		One				/store the address of another list (if needed)
-    				Store 		ListAllocation
+				Load 		ListAllocation 	/Move this pointer up (one value), ready to
+				Add 		One				/store the address of another list (if needed)
+				Store 		ListAllocation
 
- 					Load 		Counter			/Load the counter (which decreases every time a value
-                							/is entered to the current list
+ 				Load 		Counter			/Load the counter (which decreases every time a value
+											/is entered to the current list
 
 EnterItems,		Skipcond 	800				/Don't end if there are still items left to enter
 				Jump 		StopEnterItems
 
-    			Load 		ListAddPointer 	/Move list pointer up by one value
-                Add 		One
-                Store 		ListAddPointer
+				Load 		ListAddPointer 	/Move list pointer up by one value
+				Add 		One
+				Store 		ListAddPointer
 
-                Input 						/Enter item
-                StoreI 		ListAddPointer	/Store to the location of the pointer
+				Input 						/Enter item
+				StoreI 		ListAddPointer	/Store to the location of the pointer
 
-                Load 		Counter 		/Reduce counter by one
-                Add 		MinOne
-                Store 		Counter
+				Load 		Counter 		/Reduce counter by one
+				Add 		MinOne
+				Store 		Counter
 
-                Jump 		EnterItems		/Repeat
+				Jump 		EnterItems		/Repeat
 
 StopEnterItems,	Load 		ListAddPointer 	/Move the list pointer up one more time
-                Add 		One
-                Store 		ListAddPointer 	/Reset both list pointer and the actual starting
-                Store		ListAddress		/address to the next available spot for a new list
+				Add 		One
+				Store 		ListAddPointer 	/Reset both list pointer and the actual starting
+				Store		ListAddress		/address to the next available spot for a new list
 
 
 				/Call the quicksort subroutine
 
-                /Store arguments onto the stack
-                Load 		StackPointer 	/Move stack pointer up by one (allocates a slot in the stack
-                Add 		MinOne			/for a value to store)
-                Store 		StackPointer
+				/Store arguments onto the stack
+				Load 		StackPointer 	/Move stack pointer up by one (allocates a slot in the stack
+				Add 		MinOne			/for a value to store)
+				Store 		StackPointer
 
-                /Store the size of required list to sort on the stack
-                Load 		ListAllocation 	/Load the address of the list to sort. This is at the
-                Add 		MinOne			/list of the address of lists
+				/Store the size of required list to sort on the stack
+				Load 		ListAllocation 	/Load the address of the list to sort. This is at the
+				Add 		MinOne			/list of the address of lists
 
-                Store 		temp 			/Store this value to temp first
+				Store 		temp 			/Store this value to temp first
 
-                LoadI 		temp 			/Then load the list's start address (containing the size value)
-                							/by indirect load
-                Store 		temp 			/Save address to temp
-                LoadI 		temp 			/Load indirectly again to obtain the size value
-                StoreI 		StackPointer 	/Store to stack
+				LoadI 		temp 			/Then load the list's start address (containing the size value)
+											/by indirect load
+				Store 		temp 			/Save address to temp
+				LoadI 		temp 			/Load indirectly again to obtain the size value
+				StoreI 		StackPointer 	/Store to stack
 
-                /Store the address of the first item of the list (i.e. not including the size value)
-                Load 		StackPointer 	/Move stack pointer up
-                Add 		MinOne
-                Store 		StackPointer
+				/Store the address of the first item of the list (i.e. not including the size value)
+				Load 		StackPointer 	/Move stack pointer up
+				Add 		MinOne
+				Store 		StackPointer
 
-                Load 		ListAllocation 	/Take address of the list required
-                Add 		MinOne			/(Negative 1 offset first, as before)
-                Store 		temp			/Load indirectly to obtain the list's address
-                LoadI 		temp
-                Add 		One				/Add an offset of 1 to ignore the size value
-                StoreI 		StackPointer 	/Store address to the stack
+				Load 		ListAllocation 	/Take address of the list required
+				Add 		MinOne			/(Negative 1 offset first, as before)
+				Store 		temp			/Load indirectly to obtain the list's address
+				LoadI 		temp
+				Add 		One				/Add an offset of 1 to ignore the size value
+				StoreI 		StackPointer 	/Store address to the stack
 
 				/Jump to quicksort
-                JnS 		quicksort
+				JnS 		quicksort
 
-                /Return from quicksort
-                Load 		StackPointer	/This moves the stack pointer to its original location (clears
+				/Return from quicksort
+				Load 		StackPointer	/This moves the stack pointer to its original location (clears
 				AddI 		Two				/stored values on the stack) from where the subroutine began
-                StoreI 		StackPointer
+				StoreI 		StackPointer
 				/End quicksort subroutine
 
-                /Print the sorted list
-                Load 		ListAllocation 	/Load the location of the list's address
-                Add 		MinOne
-                Store 		temp
-                LoadI		temp			/This loads the list's address
-                Store 		temp
-                LoadI		temp			/and take the size of the list
-                Store 		t0				/to store into t0 (this is a counter)
+				/Print the sorted list
+				Load 		ListAllocation 	/Load the location of the list's address
+				Add 		MinOne
+				Store 		temp
+				LoadI		temp			/This loads the list's address
+				Store 		temp
+				LoadI		temp			/and take the size of the list
+				Store 		t0				/to store into t0 (this is a counter)
 
-                Load 		temp			/Load address from temp and add one
-                Add 		One
-                Store 		t1				/store to t1. It is a temporary list pointer
+				Load 		temp			/Load address from temp and add one
+				Add 		One
+				Store 		t1				/store to t1. It is a temporary list pointer
 
-                Load 		t0				/Load counter
+				Load 		t0				/Load counter
 
 PrintList,		Skipcond	800				/Continue to print if the counter hasn't reached 0
 				Jump 		EndMain
 
-                LoadI		t1				/Load item in the list pointer
-                Output
+				LoadI		t1				/Load item in the list pointer
+				Output
 
-                Load 		t1				/Move list pointer up
-                Add 		One
-                Store		t1
+				Load 		t1				/Move list pointer up
+				Add 		One
+				Store		t1
 
-                Load 		t0				/Reduce counter by one
-                Add 		MinOne
-                Store 		t0
+				Load 		t0				/Reduce counter by one
+				Add 		MinOne
+				Store 		t0
 
-                Jump 		PrintList
+				Jump 		PrintList
 
-EndMain,       	Halt
+EndMain,			Halt
 
 /Start of quicksort subroutine
 quicksort, 		HEX 		000				/Stores the most recent return address (PC value)
 
-                Load 		StackPointer 	/Move stack pointer up
-                Add 		MinOne
-                Store 		StackPointer
+				Load 		StackPointer 	/Move stack pointer up
+				Add 		MinOne
+				Store 		StackPointer
 
-                Load 		quicksort 		/Take the return address created from JnS
-                StoreI 		StackPointer	/and store on the stack for later use. This is done as a
-                							/result of the recursive subroutine
+				Load 		quicksort 		/Take the return address created from JnS
+				StoreI 		StackPointer	/and store on the stack for later use. This is done as a
+											/result of the recursive subroutine
 
 
 				/Load the arguments from the caller, and store onto the stack as local variables
-                /size
-                Load 		StackPointer 	/Move stack pointer up
-                Add 		MinOne
-                Store 		StackPointer
+				/size
+				Load 		StackPointer 	/Move stack pointer up
+				Add 		MinOne
+				Store 		StackPointer
 
-                Load 		StackPointer 	/Obtain the argument 'size' by first loading the stack pointer
-                Add 		One				/then adding an offset of +3 from the stack pointer
-                Add 		Two				/to find the relative location of the actual argument required
-                Store 		temp			/Store the address of where the argument is (to temp)
-                LoadI 		temp			/and load indirectly from it
-                StoreI 		StackPointer	/Store the size to the top of the stack
+				Load 		StackPointer 	/Obtain the argument 'size' by first loading the stack pointer
+				Add 		One				/then adding an offset of +3 from the stack pointer
+				Add 		Two				/to find the relative location of the actual argument required
+				Store 		temp			/Store the address of where the argument is (to temp)
+				LoadI 		temp			/and load indirectly from it
+				StoreI 		StackPointer	/Store the size to the top of the stack
 
 				/listAddress
-                Load 		StackPointer 	/Move stack pointer up
-                Add 		MinOne
-                Store 		StackPointer
+				Load 		StackPointer 	/Move stack pointer up
+				Add 		MinOne
+				Store 		StackPointer
 
-                Load 		StackPointer 	/Load the stack pointer (as before)
-                Add 		One				/Notice the offset (+3) is the same as the previous argument
-                Add 		Two				/since the stack pointer has moved up
-                Store 		temp			/Similarly, store the stack pointer with the offset,
-                LoadI 		temp			/load indirectly from it
-                StoreI 		StackPointer	/then store the obtained value to the top of the stack
+				Load 		StackPointer 	/Load the stack pointer (as before)
+				Add 		One				/Notice the offset (+3) is the same as the previous argument
+				Add 		Two				/since the stack pointer has moved up
+				Store 		temp			/Similarly, store the stack pointer with the offset,
+				LoadI 		temp			/load indirectly from it
+				StoreI 		StackPointer	/then store the obtained value to the top of the stack
 
 
 				/Allocate more local variables
-                /Save the end address of the list to the stack
-                Load 		StackPointer 	/Move stack pointer up
-                Add		 	MinOne
-                Store 		StackPointer
+				/Save the end address of the list to the stack
+				Load 		StackPointer 	/Move stack pointer up
+				Add		 	MinOne
+				Store 		StackPointer
 
-                /The end address requires some arithmetic:
-                Load 		StackPointer 	/Load list address and save to temporary label (t0)
-                Add 		One
-                Store 		temp
-                LoadI 		temp
-                Store 		t0
+				/The end address requires some arithmetic:
+				Load 		StackPointer 	/Load list address and save to temporary label (t0)
+				Add 		One
+				Store 		temp
+				LoadI 		temp
+				Store 		t0
 
-                Load 		StackPointer	/Load the size of the list
-                Add		 	Two
-                Store 		temp
-                LoadI 		temp
+				Load 		StackPointer	/Load the size of the list
+				Add		 	Two
+				Store 		temp
+				LoadI 		temp
 
-                Add 		MinOne 			/Reduce the size by one. This value is added to the starting
-                							/address of the list, which gets an address which points
-                                            /to the last item of the list
+				Add 		MinOne 			/Reduce the size by one. This value is added to the starting
+											/address of the list, which gets an address which points
+											/to the last item of the list
 
-                Add 		t0 				/Add the list address to the modified size value, resulting in the
-                							/required end address
-                StoreI 		StackPointer	/and store to the stack
+				Add 		t0 				/Add the list address to the modified size value, resulting in the
+											/required end address
+				StoreI 		StackPointer	/and store to the stack
 
 				/Calculate and store the left mark (Lmark)
-                Load 		StackPointer 	/Move stack pointer up
-                Add 		MinOne
-                Store 		StackPointer
+				Load 		StackPointer 	/Move stack pointer up
+				Add 		MinOne
+				Store 		StackPointer
 
-                Load 		StackPointer 	/Lmark is the list address (which will be described as 'start' as
-                							/a local variable) plus one. The first item is ignored since that
-                                           	/is being compared with the rest of the list
-                Add 		Two				/(Variable) start is at offset of +2
-                Store 		temp
-                LoadI 		temp			/Load start, add one (as described above) and then store to stack
-                Add 		One
-                StoreI 		StackPointer
+				Load 		StackPointer 	/Lmark is the list address (which will be described as 'start' as
+											/a local variable) plus one. The first item is ignored since that
+												/is being compared with the rest of the list
+				Add 		Two				/(Variable) start is at offset of +2
+				Store 		temp
+				LoadI 		temp			/Load start, add one (as described above) and then store to stack
+				Add 		One
+				StoreI 		StackPointer
 
 				/Calculate and store the right mark (Rmark)
-                Load 		StackPointer 	/Move stack pointer up
-                Add 		MinOne
-                Store 		StackPointer
+				Load 		StackPointer 	/Move stack pointer up
+				Add 		MinOne
+				Store 		StackPointer
 
-                Load 		StackPointer 	/Rmark is the ending address of the list, which was already
-                Add 		Two				/calculated previously. It is stored at an offset of +2
-                Store 		temp
-                LoadI 		temp
-                StoreI 		StackPointer
+				Load 		StackPointer 	/Rmark is the ending address of the list, which was already
+				Add 		Two				/calculated previously. It is stored at an offset of +2
+				Store 		temp
+				LoadI 		temp
+				StoreI 		StackPointer
 
-    			/Compares the start address and end address. This will stop the sort if they are the same
-                /(i.e. if the size of the list is less than 2)
+				/Compares the start address and end address. This will stop the sort if they are the same
+				/(i.e. if the size of the list is less than 2)
 			 	Load 		StackPointer 	/take start address and place into t0
-                Add 		One
-                Add 		Two
-                Store 		temp
-                LoadI 		temp
-                Store 		t0
+				Add 		One
+				Add 		Two
+				Store 		temp
+				LoadI 		temp
+				Store 		t0
 
-                Load 		StackPointer 	/Load end address
-                Add 		Two
-                Store 		temp
-                LoadI 		temp
+				Load 		StackPointer 	/Load end address
+				Add 		Two
+				Store 		temp
+				LoadI 		temp
 
-                Subt 		t0 				/Find the difference (end - start)
+				Subt 		t0 				/Find the difference (end - start)
 
-                Skipcond 	800 			/If start address is less (giving a positive value), then
-                							/continue the sort
-                Jump 		EndImmediately	/Otherwise, end the subroutine
+				Skipcond 	800 			/If start address is less (giving a positive value), then
+											/continue the sort
+				Jump 		EndImmediately	/Otherwise, end the subroutine
 
-   				/This is the main loop in which items are swapped based on their value compared to the
-                /starting item. It starts with a condition to check if the marks have crossed or not
+					/This is the main loop in which items are swapped based on their value compared to the
+				/starting item. It starts with a condition to check if the marks have crossed or not
 MainSort, 		LoadI 		StackPointer 	/Load Rmark (already at the top of the stack) and store to t0
-                Store 		t0
+				Store 		t0
 
-                Load 		StackPointer 	/Load Lmark
-                Add 		One
-                Store 		temp
-                LoadI 		temp
+				Load 		StackPointer 	/Load Lmark
+				Add 		One
+				Store 		temp
+				LoadI 		temp
 
-                Subt 		t0				/Find Lmark - Rmark
+				Subt 		t0				/Find Lmark - Rmark
 
-                Skipcond 	800				/If Lmark > Rmark, then move on to sort the next partitions
-                Jump 		ReduceRmark		/Otherwise, start/continue the current sort
-                Jump 		NextSort
+				Skipcond 	800				/If Lmark > Rmark, then move on to sort the next partitions
+				Jump 		ReduceRmark		/Otherwise, start/continue the current sort
+				Jump 		NextSort
 
-    			/Keep reducing Rmark until it finds an item that is less than or equal to the start item
+				/Keep reducing Rmark until it finds an item that is less than or equal to the start item
 ReduceRmark, 	Load 		StackPointer 	/Load item in start address and store to t0
 				Add 		One
-                Add 		Two
-                Store 		temp
-                LoadI 		temp			/This loads the start address
-                Store 		temp
-                LoadI 		temp 			/This loads the item in the start address
-                Store 		t0
+				Add 		Two
+				Store 		temp
+				LoadI 		temp			/This loads the start address
+				Store 		temp
+				LoadI 		temp 			/This loads the item in the start address
+				Store 		t0
 
-                Load 		StackPointer 	/Load item in the Rmark address
-                Store 		temp
-                LoadI 		temp			/This loads the Rmark address
-                Store 		temp
-                LoadI 		temp 			/This loads the item
+				Load 		StackPointer 	/Load item in the Rmark address
+				Store 		temp
+				LoadI 		temp			/This loads the Rmark address
+				Store 		temp
+				LoadI 		temp 			/This loads the item
 
-                Subt 		t0				/Find the difference between the two items
-                							/L[Rmark] - L[start] (to relate to a high-level language)
+				Subt 		t0				/Find the difference between the two items
+											/L[Rmark] - L[start] (to relate to a high-level language)
 
-                Skipcond 	800 			/Only continue to move Rmark if the item in it is still greater
-                							/than the item in start address
+				Skipcond 	800 			/Only continue to move Rmark if the item in it is still greater
+											/than the item in start address
 				Jump 		IncreaseLmark	/Otherwise, move on and increase Lmark
 
-                LoadI 		StackPointer 	/Decrease Rmark (by one)
-                Add 		MinOne
-                StoreI 		StackPointer
+				LoadI 		StackPointer 	/Decrease Rmark (by one)
+				Add 		MinOne
+				StoreI 		StackPointer
 
-                Jump 		ReduceRmark		/Repeat the above loop
+				Jump 		ReduceRmark		/Repeat the above loop
 
-           		/Keep increasing Lmark until it finds an item that is greater than the start item
+					/Keep increasing Lmark until it finds an item that is greater than the start item
 IncreaseLmark,	Load 		StackPointer 	/Load item in start address and store to t0
-                Add	 		One
-                Add 		Two
-                Store 		temp
-                LoadI 		temp			/This loads the start address
-                Store 		temp
-                LoadI 		temp 			/This loads the item in the start address
-                Store 		t0
+				Add	 		One
+				Add 		Two
+				Store 		temp
+				LoadI 		temp			/This loads the start address
+				Store 		temp
+				LoadI 		temp 			/This loads the item in the start address
+				Store 		t0
 
-                Load 		StackPointer 	/Load item in the Lmark address
-                Add 		One
-                Store 		temp
-                LoadI 		temp			/This loads the Lmark address
-                Store 		temp
-                LoadI 		temp 			/This loads the item
+				Load 		StackPointer 	/Load item in the Lmark address
+				Add 		One
+				Store 		temp
+				LoadI 		temp			/This loads the Lmark address
+				Store 		temp
+				LoadI 		temp 			/This loads the item
 
-                Subt 		t0 				/Find the difference between the two items
-                							/L[Lmark] - L[start]
+				Subt 		t0 				/Find the difference between the two items
+											/L[Lmark] - L[start]
 
-                Skipcond 	800				/Unlike when moving the Rmark, this loop is continued if the Lmark
-                							/is less than or equal to the start item. This means the loop breaks
-                                            /if L[Lmark] - L[start] > 0 (one condition), instead of finding
-                                            /if L[start] - L[Lmarl] <= 0 (two conditions - less/equal)
+				Skipcond 	800				/Unlike when moving the Rmark, this loop is continued if the Lmark
+											/is less than or equal to the start item. This means the loop breaks
+											/if L[Lmark] - L[start] > 0 (one condition), instead of finding
+											/if L[start] - L[Lmarl] <= 0 (two conditions - less/equal)
 
-                Jump 		InIntermediate	/Jump to an intermediate label (in the same loop) if the above
-                							/condition is false
+				Jump 		InIntermediate	/Jump to an intermediate label (in the same loop) if the above
+											/condition is false
 
-                Jump 		SwapMarks		/If true, however, it moves on to the next part
+				Jump 		SwapMarks		/If true, however, it moves on to the next part
 
-    			/Intermediate label of IncreasingLmark
+				/Intermediate label of IncreasingLmark
 InIntermediate,	Load 		StackPointer 	/Move Lmark up by one
-                Add 		One
-                Store 		temp
-                LoadI 		temp
-                Add 		One
-                Store 		t0 				/Save Lmark to t0 first, as it will be stored back into the stack
+				Add 		One
+				Store 		temp
+				LoadI 		temp
+				Add 		One
+				Store 		t0 				/Save Lmark to t0 first, as it will be stored back into the stack
 											/(which in itself requires more arithmetics)
 
-                Load 		StackPointer 	/Load the stack pointer with an offset for Lmark item (+1)
-                Add 		One
-                Store 		temp 			/Save to temp, so that Lmark can be stored indirectly to it
+				Load 		StackPointer 	/Load the stack pointer with an offset for Lmark item (+1)
+				Add 		One
+				Store 		temp 			/Save to temp, so that Lmark can be stored indirectly to it
 
-                Load 		t0 				/Load the modified Lmark
-                StoreI 		temp 			/Indirectly store to the relevant stack location
+				Load 		t0 				/Load the modified Lmark
+				StoreI 		temp 			/Indirectly store to the relevant stack location
 
 				/If Lmark is at the end of the list, then stop moving it up further
-                Load 		StackPointer 	/Load end address from stack
-                Add 		Two
-                Store 		temp
-                LoadI 		temp
-                Store 		t0
+				Load 		StackPointer 	/Load end address from stack
+				Add 		Two
+				Store 		temp
+				LoadI 		temp
+				Store 		t0
 
-                Load 		StackPointer 	/Load Lmark
-                Add 		One
-                Store 		temp
-                LoadI 		temp
+				Load 		StackPointer 	/Load Lmark
+				Add 		One
+				Store 		temp
+				LoadI 		temp
 
-                Subt 		t0
+				Subt 		t0
 
-                Skipcond 	000 			/If Lmark is greater than or equal to the end address, then stop
-                							/moving it and move on to next part
-                Jump 		SwapMarks
+				Skipcond 	000 			/If Lmark is greater than or equal to the end address, then stop
+											/moving it and move on to next part
+				Jump 		SwapMarks
 
-                Jump 		IncreaseLmark 	/Otherwise, continue to move it
+				Jump 		IncreaseLmark 	/Otherwise, continue to move it
 
-    			/This swaps the items in Lmark and Rmark once they point to items
-                /that met the above conditions
+				/This swaps the items in Lmark and Rmark once they point to items
+				/that met the above conditions
 SwapMarks,		Load 		StackPointer 	/Load Lmark
-                Add 		One
-                Store 		temp
-                LoadI 		temp
-                Store 		t0
+				Add 		One
+				Store 		temp
+				LoadI 		temp
+				Store 		t0
 
-                LoadI 		StackPointer 	/Load Rmark
+				LoadI 		StackPointer 	/Load Rmark
 
-                Subt 		t0				/Find Rmark - Lmark
+				Subt 		t0				/Find Rmark - Lmark
 
-                Skipcond 	800 			/Swap if Rmark > Lmark (i.e. don't swap if the marks
-                							/have crossed or are equal)
-                Jump 		MainSort		/Jump back to the start of the outer loop
+				Skipcond 	800 			/Swap if Rmark > Lmark (i.e. don't swap if the marks
+											/have crossed or are equal)
+				Jump 		MainSort		/Jump back to the start of the outer loop
 
 		 		Load 		StackPointer 	/Load item in Lmark and store to t0
-                Add 		One
-                Store 		temp
-                LoadI 		temp
-                Store 		temp
-                LoadI 		temp
-                Store 		t0
+				Add 		One
+				Store 		temp
+				LoadI 		temp
+				Store 		temp
+				LoadI 		temp
+				Store 		t0
 
-                Load 		StackPointer 	/Load item in Rmark address and store to t1
-                Store 		temp
-                LoadI 		temp
-                Store 		temp
-                LoadI 		temp
-                Store 		t1
+				Load 		StackPointer 	/Load item in Rmark address and store to t1
+				Store 		temp
+				LoadI 		temp
+				Store 		temp
+				LoadI 		temp
+				Store 		t1
 
-                Load 		StackPointer	/Save item in Lmark into Rmark
-                Store 		temp
-                LoadI 		temp			/This loads the Rmark address and stores it
-                Store 		temp
-                Load 		t0				/This loads the item in Lmark (in t0) and
-                StoreI 		temp			/indirectly stores it into Rmark's address
+				Load 		StackPointer	/Save item in Lmark into Rmark
+				Store 		temp
+				LoadI 		temp			/This loads the Rmark address and stores it
+				Store 		temp
+				Load 		t0				/This loads the item in Lmark (in t0) and
+				StoreI 		temp			/indirectly stores it into Rmark's address
 
-                Load 		StackPointer 	/Save item in Rmark into Lmark
-                Add 		One
-                Store	 	temp
-                LoadI 		temp			/This loads the Lmark address and stores it
-                Store 		temp
-                Load 		t1				/This loads the item in Lmark (in t1) and
-                StoreI 		temp			/indirectly stores it into Rmark's address
+				Load 		StackPointer 	/Save item in Rmark into Lmark
+				Add 		One
+				Store	 	temp
+				LoadI 		temp			/This loads the Lmark address and stores it
+				Store 		temp
+				Load 		t1				/This loads the item in Lmark (in t1) and
+				StoreI 		temp			/indirectly stores it into Rmark's address
 
-                Jump 		MainSort		/Jump back to the start of the outer loop
+				Jump 		MainSort		/Jump back to the start of the outer loop
 
 				/Swaps the start item with the Rmark item and then recursively sorts the remaining halves
-                /of the list partitioned by Rmark
+				/of the list partitioned by Rmark
 NextSort,		Load 		StackPointer 	/Load item in start address to swap with item in Rmark
-                Add 		One				/(store item in t0 first)
-                Add 		Two
-                Store 		temp
-                LoadI 		temp
-                Store 		temp
-                LoadI 		temp
-                Store 		t0
+				Add 		One				/(store item in t0 first)
+				Add 		Two
+				Store 		temp
+				LoadI 		temp
+				Store 		temp
+				LoadI 		temp
+				Store 		t0
 
-                Load 		StackPointer 	/Load item in Rmark address and store to t1
-                Store 		temp
-                LoadI 		temp
-                Store 		temp
-                LoadI 		temp
-                Store 		t1
+				Load 		StackPointer 	/Load item in Rmark address and store to t1
+				Store 		temp
+				LoadI 		temp
+				Store 		temp
+				LoadI 		temp
+				Store 		t1
 
-                Load 		StackPointer 	/Save item in start into Rmark
-                Store 		temp
-                LoadI 		temp
-                Store 		temp
-                Load 		t0
-                StoreI 		temp
+				Load 		StackPointer 	/Save item in start into Rmark
+				Store 		temp
+				LoadI 		temp
+				Store 		temp
+				Load 		t0
+				StoreI 		temp
 
-                Load 		StackPointer 	/Save item in Rmark into start
-                Add 		One
-                Add 		Two
-                Store 		temp
-                LoadI 		temp
-                Store 		temp
-                Load 		t1
-                StoreI 		temp
+				Load 		StackPointer 	/Save item in Rmark into start
+				Add 		One
+				Add 		Two
+				Store 		temp
+				LoadI 		temp
+				Store 		temp
+				Load 		t1
+				StoreI 		temp
 
-                /Call quicksort on first half of list, from start address to Rmark - 1 address
-                /Store the size of the first half
-                Load 		StackPointer 	/Move stack pointer up
-                Add 		MinOne
-                Store 		StackPointer
+				/Call quicksort on first half of list, from start address to Rmark - 1 address
+				/Store the size of the first half
+				Load 		StackPointer 	/Move stack pointer up
+				Add 		MinOne
+				Store 		StackPointer
 
-                /The size is given by Rmark - start
-                Load 		StackPointer 	/Load start address and save to t0
-                Add 		Four
-                Store 		temp
-                LoadI 		temp
-                Store 		t0
+				/The size is given by Rmark - start
+				Load 		StackPointer 	/Load start address and save to t0
+				Add 		Four
+				Store 		temp
+				LoadI 		temp
+				Store 		t0
 
-                Load 		StackPointer 	/Load Rmark
-                Add 		One
-                Store 		temp
-                LoadI 		temp
+				Load 		StackPointer 	/Load Rmark
+				Add 		One
+				Store 		temp
+				LoadI 		temp
 
-                Subt 		t0 				/This subtraction gives the size
-                StoreI 		StackPointer
+				Subt 		t0 				/This subtraction gives the size
+				StoreI 		StackPointer
 
 				/Store start address
-                Load 		StackPointer 	/Move stack pointer up
-                Add 		MinOne
-                Store 		StackPointer
+				Load 		StackPointer 	/Move stack pointer up
+				Add 		MinOne
+				Store 		StackPointer
 
-                Load 		StackPointer 	/Load start and save to argument
-                Add 		One
-                Add 		Four
-                Store 		temp
-                LoadI 		temp
-                StoreI 		StackPointer
-
-				/Jump to quicksort
-                JnS 		quicksort
-
-                /Return from quicksort
-                Load 		StackPointer 	/Clear stored values
-                Add 		Two
-                Store 		StackPointer
-
-
-                /Call quicksort on the second half of the list, from Rmark + 1 address to end address
-                /Store the size of the second half
-                Load 		StackPointer 	/Move stack pointer up
-                Add 		MinOne
-                Store 		StackPointer
-
-                Load 		StackPointer 	/Load Rmark and save to t0
-                Add		 	One
-                Store 		temp
-                LoadI 		temp
-                Store 		t0
-
-                Load 		StackPointer 	/Load end address
-                Add 		Two
-                Add 		One
-                Store 		temp
-                LoadI 		temp
-
-                Subt 		t0				/This subtraction gives the size
-                StoreI 		StackPointer
-
-				/Store start address (which in this case is Rmark + 1)
-                Load 		StackPointer 	/Move stackPointer up
-                Add 		MinOne
-                Store 		StackPointer
-
-                Load 		StackPointer 	/Load Rmark
-                Add 		Two
-                Store 		temp
-                LoadI 		temp
-                Add 		One				/Add one to that address
-                StoreI 		StackPointer	/Store to stack
+				Load 		StackPointer 	/Load start and save to argument
+				Add 		One
+				Add 		Four
+				Store 		temp
+				LoadI 		temp
+				StoreI 		StackPointer
 
 				/Jump to quicksort
-                JnS 		quicksort
+				JnS 		quicksort
 
 				/Return from quicksort
-                Load 		StackPointer 	/Clear stored values
-                Add 		Two
-                Store 		StackPointer
+				Load 		StackPointer 	/Clear stored values
+				Add 		Two
+				Store 		StackPointer
+
+
+				/Call quicksort on the second half of the list, from Rmark + 1 address to end address
+				/Store the size of the second half
+				Load 		StackPointer 	/Move stack pointer up
+				Add 		MinOne
+				Store 		StackPointer
+
+				Load 		StackPointer 	/Load Rmark and save to t0
+				Add		 	One
+				Store 		temp
+				LoadI 		temp
+				Store 		t0
+
+				Load 		StackPointer 	/Load end address
+				Add 		Two
+				Add 		One
+				Store 		temp
+				LoadI 		temp
+
+				Subt 		t0				/This subtraction gives the size
+				StoreI 		StackPointer
+
+				/Store start address (which in this case is Rmark + 1)
+				Load 		StackPointer 	/Move stackPointer up
+				Add 		MinOne
+				Store 		StackPointer
+
+				Load 		StackPointer 	/Load Rmark
+				Add 		Two
+				Store 		temp
+				LoadI 		temp
+				Add 		One				/Add one to that address
+				StoreI 		StackPointer	/Store to stack
+
+				/Jump to quicksort
+				JnS 		quicksort
+
+				/Return from quicksort
+				Load 		StackPointer 	/Clear stored values
+				Add 		Two
+				Store 		StackPointer
 
 				/End the sort, continuing from where the subroutine was called
 EndImmediately,	Load 		StackPointer	/Clear stored values created by the subroutine
-                Add 		One
-                Add 		Four
-                Store 		StackPointer
+				Add 		One
+				Add 		Four
+				Store 		StackPointer
 
-                LoadI 		StackPointer	/Now the stack pointer points to the return address
-                Store 		temp			/which is loaded and stored to temp
+				LoadI 		StackPointer	/Now the stack pointer points to the return address
+				Store 		temp			/which is loaded and stored to temp
 
-                Load 		StackPointer 	/Clear the return address from the stack
-                Add 		One
-                Store 		StackPointer
+				Load 		StackPointer 	/Clear the return address from the stack
+				Add 		One
+				Store 		StackPointer
 
-                JumpI	 	temp			/Return address is still saved in temp, so jump indirectly to it
+				JumpI	 	temp			/Return address is still saved in temp, so jump indirectly to it
 /End of quicksort subroutine

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -64,6 +64,7 @@
 	let addressHover = $state<number | null>(null);
 	let inputLogIndices = $state<number[]>([]);
 	let inputsPanel: InputsPanel | undefined;
+	let inputAlert = $state(false);
 	let showDataPath = $state(false);
 	let recentOpen = $state(false);
 	let fileInput: HTMLInputElement;
@@ -92,6 +93,7 @@
 
 	function setStatus(msg: string, cls?: string) {
 		statusText = { cls, msg };
+		inputAlert = false;
 	}
 
 	function onUpdate(newState: State, newLog: Action[]) {
@@ -152,6 +154,7 @@
 			$settings.inputsOpen = true;
 			await tick();
 			inputsPanel?.focus();
+			inputAlert = true;
 		} else if (reason === 'input-error') {
 			setStatus('Invalid input. Please edit and try again.', 'has-text-danger');
 			$settings.inputsOpen = true;
@@ -780,7 +783,11 @@
 							symbols={program?.symbols ?? {}}
 						/>
 					</CollapsiblePanel>
-					<CollapsiblePanel title="Inputs" bind:open={$settings.inputsOpen}>
+					<CollapsiblePanel
+						title="Inputs"
+						bind:open={$settings.inputsOpen}
+						alert={inputAlert}
+					>
 						<InputsPanel bind:this={inputsPanel} bind:inputs={project.inputs} />
 					</CollapsiblePanel>
 					<CollapsiblePanel title="Display" bind:open={$settings.displayOpen}>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -111,7 +111,7 @@
 
 	function onError(message: string) {
 		codeModified = false;
-		setStatus(message, 'has-text-danger');
+		setStatus(message, 'has-text-danger-on-scheme');
 	}
 
 	function onBreak(line: number) {
@@ -121,7 +121,10 @@
 
 	function onHalt(error?: string) {
 		if (error) {
-			setStatus(`Machine halted abnormally: ${error}`);
+			setStatus(
+				`Machine halted abnormally: ${error}`,
+				'has-text-danger-on-scheme',
+			);
 		} else {
 			setStatus('Machine halted normally.');
 		}
@@ -149,14 +152,17 @@
 		if (reason === 'input-empty') {
 			setStatus(
 				'Input required. Please enter input and press continue.',
-				'has-text-warning',
+				'has-text-warning-on-scheme',
 			);
 			$settings.inputsOpen = true;
 			await tick();
 			inputsPanel?.focus();
 			inputAlert = true;
 		} else if (reason === 'input-error') {
-			setStatus('Invalid input. Please edit and try again.', 'has-text-danger');
+			setStatus(
+				'Invalid input. Please edit and try again.',
+				'has-text-danger-on-scheme',
+			);
 			$settings.inputsOpen = true;
 			await tick();
 			inputsPanel?.focus();
@@ -405,7 +411,7 @@
 			loadFromString(code);
 		} catch (e) {
 			console.error(e);
-			setStatus(`Error: ${e}`, 'has-text-danger');
+			setStatus(`Error: ${e}`, 'has-text-danger-on-scheme');
 		}
 		busyState--;
 		menuOpen = null;

--- a/src/lib/CollapsiblePanel.svelte
+++ b/src/lib/CollapsiblePanel.svelte
@@ -1,13 +1,17 @@
 <script lang="ts">
 	import Fa from 'svelte-fa';
 	import { faCaretRight, faCaretDown } from '@fortawesome/free-solid-svg-icons';
-	export let title: string;
-	export let open = false;
+	import type { Snippet } from 'svelte';
+	let {
+		title,
+		open = $bindable(false),
+		children,
+	}: { title: string; open?: boolean; children: Snippet } = $props();
 </script>
 
-<!-- svelte-ignore a11y-no-static-element-interactions -->
-<!-- svelte-ignore a11y-click-events-have-key-events -->
-<div class="top" on:click={() => (open = !open)}>
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<div class="top" onclick={() => (open = !open)}>
 	<span class="icon">
 		<Fa icon={open ? faCaretDown : faCaretRight} />
 	</span>
@@ -15,7 +19,7 @@
 </div>
 {#if open}
 	<div class="bottom">
-		<slot />
+		{@render children()}
 	</div>
 {/if}
 

--- a/src/lib/CollapsiblePanel.svelte
+++ b/src/lib/CollapsiblePanel.svelte
@@ -5,13 +5,19 @@
 	let {
 		title,
 		open = $bindable(false),
+		alert = false,
 		children,
-	}: { title: string; open?: boolean; children: Snippet } = $props();
+	}: {
+		title: string;
+		open?: boolean;
+		alert?: boolean;
+		children: Snippet;
+	} = $props();
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <!-- svelte-ignore a11y_click_events_have_key_events -->
-<div class="top" onclick={() => (open = !open)}>
+<div class="top" class:alert onclick={() => (open = !open)}>
 	<span class="icon">
 		<Fa icon={open ? faCaretDown : faCaretRight} />
 	</span>
@@ -33,6 +39,26 @@
 		border-bottom: solid 1px var(--bulma-border);
 		cursor: pointer;
 		background-color: var(--bulma-scheme-main-bis);
+	}
+
+	@keyframes flash {
+		0% {
+			background-color: var(--bulma-scheme-main-bis);
+			color: var(--bulma-body-color);
+		}
+		70% {
+			background-color: var(--bulma-warning);
+			color: var(--bulma-warning-invert);
+		}
+	}
+
+	.alert {
+		animation-name: flash;
+		animation-duration: 0.3s;
+		animation-direction: alternate-reverse;
+		animation-iteration-count: 6;
+		background-color: var(--bulma-warning);
+		color: var(--bulma-warning-invert);
 	}
 	.bottom {
 		flex: 0 1 auto;

--- a/src/lib/DataPath.svelte
+++ b/src/lib/DataPath.svelte
@@ -2,16 +2,15 @@
 	import type { Action, State, Register } from '../marie';
 	import { hex, logWatcher } from '../utils';
 
-	export let state: State;
-	export let log: Action[];
+	let { state: machine, log }: { state: State; log: Action[] } = $props();
 
-	let action: Action | null = null;
-	let step = 0;
+	let action = $state<Action | null>(null);
+	let step = $state(0);
 
 	type Source = Register | 'M' | 'ADD' | 'SUB' | null;
 	type Target = Register | 'M' | 'INC_PC' | null;
-	let read: Source = null;
-	let write: Target = null;
+	let read = $state<Source>(null);
+	let write = $state<Target>(null);
 
 	const helpText: { [key: string]: string | undefined } = {
 		cu: 'The control unit activates read and write signals to transfer data between selected devices.',
@@ -99,7 +98,7 @@
 			step = 0;
 		},
 	);
-	$: updateLogs(log);
+	$effect(() => updateLogs(log));
 
 	function updateSignals(action: Action | null) {
 		if (action === null) {
@@ -147,8 +146,8 @@
 				write = null;
 		}
 	}
-	$: updateSignals(action);
-	$: busActive = read !== null && write !== null;
+	$effect(() => updateSignals(action));
+	let busActive = $derived(read !== null && write !== null);
 
 	function isBusTransferActive(
 		target: Target,
@@ -171,7 +170,7 @@
 		return read === target && write == source;
 	}
 
-	let hover: string | null = null;
+	let hover = $state<string | null>(null);
 </script>
 
 <div class="data-path">
@@ -573,8 +572,8 @@
 						width="36.248"
 						height="105.04"
 						role="presentation"
-						on:mouseenter={() => (hover = 'cu')}
-						on:mouseleave={() => (hover = null)}
+						onmouseenter={() => (hover = 'cu')}
+						onmouseleave={() => (hover = null)}
 					/>
 					<rect
 						id="ir-chip"
@@ -586,8 +585,8 @@
 						width="23.019"
 						height="9.7896"
 						role="presentation"
-						on:mouseenter={() => (hover = 'ir')}
-						on:mouseleave={() => (hover = null)}
+						onmouseenter={() => (hover = 'ir')}
+						onmouseleave={() => (hover = null)}
 					/>
 					<rect
 						id="out-chip"
@@ -597,8 +596,8 @@
 						y="34.793"
 						width="23.019"
 						role="presentation"
-						on:mouseenter={() => (hover = 'out')}
-						on:mouseleave={() => (hover = null)}
+						onmouseenter={() => (hover = 'out')}
+						onmouseleave={() => (hover = null)}
 						height="9.7896"
 					/>
 					<rect
@@ -610,8 +609,8 @@
 						width="23.019"
 						height="9.7896"
 						role="presentation"
-						on:mouseenter={() => (hover = 'in')}
-						on:mouseleave={() => (hover = null)}
+						onmouseenter={() => (hover = 'in')}
+						onmouseleave={() => (hover = null)}
 					/>
 					<rect
 						id="ac-chip"
@@ -623,8 +622,8 @@
 						width="23.019"
 						height="9.7896"
 						role="presentation"
-						on:mouseenter={() => (hover = 'ac')}
-						on:mouseleave={() => (hover = null)}
+						onmouseenter={() => (hover = 'ac')}
+						onmouseleave={() => (hover = null)}
 					/>
 					<rect
 						id="mbr-chip"
@@ -636,8 +635,8 @@
 						width="23.019"
 						height="9.7896"
 						role="presentation"
-						on:mouseenter={() => (hover = 'mbr')}
-						on:mouseleave={() => (hover = null)}
+						onmouseenter={() => (hover = 'mbr')}
+						onmouseleave={() => (hover = null)}
 					/>
 					<rect
 						id="pc-chip"
@@ -649,8 +648,8 @@
 						width="23.019"
 						height="9.7896"
 						role="presentation"
-						on:mouseenter={() => (hover = 'pc')}
-						on:mouseleave={() => (hover = null)}
+						onmouseenter={() => (hover = 'pc')}
+						onmouseleave={() => (hover = null)}
 					/>
 					<rect
 						id="mar-chip"
@@ -662,8 +661,8 @@
 						width="23.019"
 						height="9.7896"
 						role="presentation"
-						on:mouseenter={() => (hover = 'mar')}
-						on:mouseleave={() => (hover = null)}
+						onmouseenter={() => (hover = 'mar')}
+						onmouseleave={() => (hover = null)}
 					/>
 					<rect
 						id="m-chip"
@@ -675,8 +674,8 @@
 						width="36.248"
 						height="105.04"
 						role="presentation"
-						on:mouseenter={() => (hover = 'm')}
-						on:mouseleave={() => (hover = null)}
+						onmouseenter={() => (hover = 'm')}
+						onmouseleave={() => (hover = null)}
 					/>
 				</g>
 				<path
@@ -684,8 +683,8 @@
 					class="chip"
 					class:read={read === 'ADD' || read === 'SUB'}
 					role="presentation"
-					on:mouseenter={() => (hover = 'alu')}
-					on:mouseleave={() => (hover = null)}
+					onmouseenter={() => (hover = 'alu')}
+					onmouseleave={() => (hover = null)}
 					d="m137.58 52.917h9.2604l2.6458 3.3073 2.6458-3.3073h9.2604l-7.9375 10.583h-7.9375z"
 				/>
 			</g>
@@ -985,7 +984,7 @@
 							y="42.283726"
 							font-size="6.35px"
 							stroke-width=".26458"
-							style="line-height:1.25">{hex(state.registers.IR)}</tspan
+							style="line-height:1.25">{hex(machine.registers.IR)}</tspan
 						></text
 					>
 					<text
@@ -1001,7 +1000,7 @@
 							y="42.283726"
 							font-size="6.35px"
 							stroke-width=".26458"
-							style="line-height:1.25">{hex(state.registers.OUT)}</tspan
+							style="line-height:1.25">{hex(machine.registers.OUT)}</tspan
 						></text
 					>
 					<text
@@ -1017,7 +1016,7 @@
 							y="42.283726"
 							font-size="6.35px"
 							stroke-width=".26458"
-							style="line-height:1.25">{hex(state.registers.IN)}</tspan
+							style="line-height:1.25">{hex(machine.registers.IN)}</tspan
 						></text
 					>
 					<text
@@ -1034,7 +1033,7 @@
 							font-size="6.35px"
 							stroke-width=".26458"
 							style="line-height:1.25"
-							>{hex(state.memory[state.registers.MAR])}</tspan
+							>{hex(machine.memory[machine.registers.MAR])}</tspan
 						></text
 					>
 					<text
@@ -1050,7 +1049,7 @@
 							y="42.280621"
 							font-size="6.35px"
 							stroke-width=".26458"
-							style="line-height:1.25">{hex(state.registers.AC)}</tspan
+							style="line-height:1.25">{hex(machine.registers.AC)}</tspan
 						></text
 					>
 					<text
@@ -1066,7 +1065,7 @@
 							y="42.280621"
 							font-size="6.35px"
 							stroke-width=".26458"
-							style="line-height:1.25">{hex(state.registers.MBR)}</tspan
+							style="line-height:1.25">{hex(machine.registers.MBR)}</tspan
 						></text
 					>
 					<text
@@ -1082,7 +1081,7 @@
 							y="42.280621"
 							font-size="6.35px"
 							stroke-width=".26458"
-							style="line-height:1.25">{hex(state.registers.PC, 3)}</tspan
+							style="line-height:1.25">{hex(machine.registers.PC, 3)}</tspan
 						></text
 					>
 					<text
@@ -1098,7 +1097,7 @@
 							y="42.280621"
 							font-size="6.35px"
 							stroke-width=".26458"
-							style="line-height:1.25">{hex(state.registers.MAR, 3)}</tspan
+							style="line-height:1.25">{hex(machine.registers.MAR, 3)}</tspan
 						></text
 					>
 				</g>
@@ -1191,8 +1190,8 @@
 				width="193.52"
 				height="9.9157"
 				role="presentation"
-				on:mouseenter={() => (hover = 'read')}
-				on:mouseleave={() => (hover = null)}
+				onmouseenter={() => (hover = 'read')}
+				onmouseleave={() => (hover = null)}
 			/>
 			<rect
 				id="write-hover"
@@ -1201,15 +1200,15 @@
 				width="193.52"
 				height="9.3544"
 				role="presentation"
-				on:mouseenter={() => (hover = 'write')}
-				on:mouseleave={() => (hover = null)}
+				onmouseenter={() => (hover = 'write')}
+				onmouseleave={() => (hover = null)}
 			/>
 			<path
 				id="ac-sign-hover"
 				d="m38.229 63.789 119.31-0.39688 2.5136-7.4171 4.9551-3.4036 0.155 19.457-144.52 0.52917-0.1151-10.496 14.972-0.37418z"
 				role="presentation"
-				on:mouseenter={() => (hover = 'acSign')}
-				on:mouseleave={() => (hover = null)}
+				onmouseenter={() => (hover = 'acSign')}
+				onmouseleave={() => (hover = null)}
 			/>
 			<rect
 				id="read-ir-hover"
@@ -1218,8 +1217,8 @@
 				width="5.7997"
 				height="23.199"
 				role="presentation"
-				on:mouseenter={() => (hover = 'readIR')}
-				on:mouseleave={() => (hover = null)}
+				onmouseenter={() => (hover = 'readIR')}
+				onmouseleave={() => (hover = null)}
 			/>
 			<rect
 				id="read-in-hover"
@@ -1228,8 +1227,8 @@
 				width="5.9868"
 				height="22.076"
 				role="presentation"
-				on:mouseenter={() => (hover = 'readIN')}
-				on:mouseleave={() => (hover = null)}
+				onmouseenter={() => (hover = 'readIN')}
+				onmouseleave={() => (hover = null)}
 			/>
 			<rect
 				id="read-ac-hover"
@@ -1238,8 +1237,8 @@
 				width="6.361"
 				height="22.638"
 				role="presentation"
-				on:mouseenter={() => (hover = 'readAC')}
-				on:mouseleave={() => (hover = null)}
+				onmouseenter={() => (hover = 'readAC')}
+				onmouseleave={() => (hover = null)}
 			/>
 			<rect
 				id="read-mbr-hover"
@@ -1248,8 +1247,8 @@
 				width="5.0514"
 				height="22.451"
 				role="presentation"
-				on:mouseenter={() => (hover = 'readMBR')}
-				on:mouseleave={() => (hover = null)}
+				onmouseenter={() => (hover = 'readMBR')}
+				onmouseleave={() => (hover = null)}
 			/>
 			<rect
 				id="read-pc-hover"
@@ -1258,8 +1257,8 @@
 				width="5.9868"
 				height="22.451"
 				role="presentation"
-				on:mouseenter={() => (hover = 'readPC')}
-				on:mouseleave={() => (hover = null)}
+				onmouseenter={() => (hover = 'readPC')}
+				onmouseleave={() => (hover = null)}
 			/>
 			<rect
 				id="read-mar-hover"
@@ -1268,8 +1267,8 @@
 				width="4.8643"
 				height="22.825"
 				role="presentation"
-				on:mouseenter={() => (hover = 'readMAR')}
-				on:mouseleave={() => (hover = null)}
+				onmouseenter={() => (hover = 'readMAR')}
+				onmouseleave={() => (hover = null)}
 			/>
 			<rect
 				id="read-m-hover"
@@ -1278,8 +1277,8 @@
 				width="24.322"
 				height="5.7997"
 				role="presentation"
-				on:mouseenter={() => (hover = 'readM')}
-				on:mouseleave={() => (hover = null)}
+				onmouseenter={() => (hover = 'readM')}
+				onmouseleave={() => (hover = null)}
 			/>
 			<rect
 				id="write-m-hover"
@@ -1288,8 +1287,8 @@
 				width="23.199"
 				height="7.4835"
 				role="presentation"
-				on:mouseenter={() => (hover = 'writeM')}
-				on:mouseleave={() => (hover = null)}
+				onmouseenter={() => (hover = 'writeM')}
+				onmouseleave={() => (hover = null)}
 			/>
 			<rect
 				id="write-ir-hover"
@@ -1298,8 +1297,8 @@
 				width="5.2385"
 				height="52.759"
 				role="presentation"
-				on:mouseenter={() => (hover = 'writeIR')}
-				on:mouseleave={() => (hover = null)}
+				onmouseenter={() => (hover = 'writeIR')}
+				onmouseleave={() => (hover = null)}
 			/>
 			<rect
 				id="write-out-hover"
@@ -1308,8 +1307,8 @@
 				width="6.361"
 				height="52.198"
 				role="presentation"
-				on:mouseenter={() => (hover = 'writeOUT')}
-				on:mouseleave={() => (hover = null)}
+				onmouseenter={() => (hover = 'writeOUT')}
+				onmouseleave={() => (hover = null)}
 			/>
 			<rect
 				id="write-ac-hover"
@@ -1318,8 +1317,8 @@
 				width="7.4835"
 				height="52.572"
 				role="presentation"
-				on:mouseenter={() => (hover = 'writeAC')}
-				on:mouseleave={() => (hover = null)}
+				onmouseenter={() => (hover = 'writeAC')}
+				onmouseleave={() => (hover = null)}
 			/>
 			<rect
 				id="write-mbr-hover"
@@ -1328,8 +1327,8 @@
 				width="6.361"
 				height="51.824"
 				role="presentation"
-				on:mouseenter={() => (hover = 'writeMBR')}
-				on:mouseleave={() => (hover = null)}
+				onmouseenter={() => (hover = 'writeMBR')}
+				onmouseleave={() => (hover = null)}
 			/>
 			<rect
 				id="write-pc-hover"
@@ -1338,8 +1337,8 @@
 				width="6.1739"
 				height="51.075"
 				role="presentation"
-				on:mouseenter={() => (hover = 'writePC')}
-				on:mouseleave={() => (hover = null)}
+				onmouseenter={() => (hover = 'writePC')}
+				onmouseleave={() => (hover = null)}
 			/>
 			<rect
 				id="inc-pc-hover"
@@ -1348,8 +1347,8 @@
 				width="6.1739"
 				height="50.327"
 				role="presentation"
-				on:mouseenter={() => (hover = 'incPC')}
-				on:mouseleave={() => (hover = null)}
+				onmouseenter={() => (hover = 'incPC')}
+				onmouseleave={() => (hover = null)}
 			/>
 			<rect
 				id="write-mar-hover"
@@ -1358,8 +1357,8 @@
 				width="5.7997"
 				height="52.385"
 				role="presentation"
-				on:mouseenter={() => (hover = 'writeMAR')}
-				on:mouseleave={() => (hover = null)}
+				onmouseenter={() => (hover = 'writeMAR')}
+				onmouseleave={() => (hover = null)}
 			/>
 			<rect
 				id="step-hover"
@@ -1368,15 +1367,15 @@
 				width="13.283"
 				height="48.83"
 				role="presentation"
-				on:mouseenter={() => (hover = 'step')}
-				on:mouseleave={() => (hover = null)}
+				onmouseenter={() => (hover = 'step')}
+				onmouseleave={() => (hover = null)}
 			/>
 			<path
 				id="alu-opcode-hover"
 				d="m40.411 10.103 0.18709 52.572h109.07l-7.2964-10.103-95.976-0.74836-0.18709-41.534z"
 				role="presentation"
-				on:mouseenter={() => (hover = 'aluOpcode')}
-				on:mouseleave={() => (hover = null)}
+				onmouseenter={() => (hover = 'aluOpcode')}
+				onmouseleave={() => (hover = null)}
 			/>
 			<rect
 				id="alu-a-hover"
@@ -1385,8 +1384,8 @@
 				width="5.2385"
 				height="8.2319"
 				role="presentation"
-				on:mouseenter={() => (hover = 'aluA')}
-				on:mouseleave={() => (hover = null)}
+				onmouseenter={() => (hover = 'aluA')}
+				onmouseleave={() => (hover = null)}
 			/>
 			<rect
 				id="alu-b-hover"
@@ -1395,8 +1394,8 @@
 				width="4.6772"
 				height="8.2319"
 				role="presentation"
-				on:mouseenter={() => (hover = 'aluB')}
-				on:mouseleave={() => (hover = null)}
+				onmouseenter={() => (hover = 'aluB')}
+				onmouseleave={() => (hover = null)}
 			/>
 			<rect
 				id="mar-m-hover"
@@ -1405,8 +1404,8 @@
 				width="6.361"
 				height="4.8643"
 				role="presentation"
-				on:mouseenter={() => (hover = 'marM')}
-				on:mouseleave={() => (hover = null)}
+				onmouseenter={() => (hover = 'marM')}
+				onmouseleave={() => (hover = null)}
 			/>
 			<rect
 				id="ir-cu-hover"
@@ -1415,16 +1414,16 @@
 				width="12.909"
 				height="4.6772"
 				role="presentation"
-				on:mouseenter={() => (hover = 'irCu')}
-				on:mouseleave={() => (hover = null)}
+				onmouseenter={() => (hover = 'irCu')}
+				onmouseleave={() => (hover = null)}
 			/><path
 				id="bus-hover"
 				d="m64.559 43.26v35.056h172.64v-3.1734h-10.717v-31.883h-3.174v31.883h-23.283v-31.883h-3.176v31.883h-25.93v-31.883h-3.174v31.883h-12.7v-12.965h-3.175v12.965h-12.701v-31.883h-3.174v31.883h-15.345v-31.883h-3.176v31.883h-23.283v-31.883h-3.1734v31.883h-23.285v-31.883z"
 				color="#000000"
 				style="-inkscape-stroke:none"
 				role="presentation"
-				on:mouseenter={() => (hover = 'bus')}
-				on:mouseleave={() => (hover = null)}
+				onmouseenter={() => (hover = 'bus')}
+				onmouseleave={() => (hover = null)}
 			/>
 		</g>
 	</svg>

--- a/src/lib/DataPath.svelte
+++ b/src/lib/DataPath.svelte
@@ -115,8 +115,8 @@
 					case 'SUB':
 						read = 'SUB';
 						break;
-					case 'CLEAR':
-						read = null;
+					case 'LOAD_IMMI':
+						read = 'IR';
 						break;
 				}
 				write = 'AC';

--- a/src/lib/Display.svelte
+++ b/src/lib/Display.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { rgb } from '../utils';
 
-	export let memory: number[];
+	let { memory }: { memory: number[] } = $props();
 
 	function getColor(memory: number[], i: number, j: number) {
 		const address = 0xf00 + 16 * i + j;

--- a/src/lib/Editor.svelte
+++ b/src/lib/Editor.svelte
@@ -42,7 +42,7 @@
 
 	import { debounce, throttle } from 'lodash';
 	import { assemble, type AssemblyError } from '../marie';
-	import { getCompletions, marieLanguage, styles } from '../syntax';
+	import { getCompletions, getTooltip, marieLanguage, styles } from '../syntax';
 
 	let {
 		text = $bindable(''),
@@ -141,6 +141,7 @@
 					themeCompartment.of([]),
 					EditorView.updateListener.of(debounce(checkCode, 250)),
 					EditorView.updateListener.of(textUpdated),
+					getTooltip,
 				],
 			}),
 		});

--- a/src/lib/Editor.svelte
+++ b/src/lib/Editor.svelte
@@ -137,6 +137,7 @@
 					marieLanguage,
 					marieLanguage.data.of({
 						autocomplete: getCompletions,
+						commentTokens: { line: '/' },
 					}),
 					themeCompartment.of([]),
 					EditorView.updateListener.of(debounce(checkCode, 250)),

--- a/src/lib/InputsPanel.svelte
+++ b/src/lib/InputsPanel.svelte
@@ -1,4 +1,4 @@
-<script lang="ts" context="module">
+<script lang="ts" module>
 	export type InputItem = {
 		format: InputOutputMode;
 		consumed: string;
@@ -11,17 +11,21 @@
 	import type { InputOutputMode } from '../settings';
 	import { faPlus, faTrash } from '@fortawesome/free-solid-svg-icons';
 
-	export let inputs: InputItem[];
+	let { inputs = $bindable() }: { inputs: InputItem[] } = $props();
 
-	let inputTextareas: (HTMLTextAreaElement | undefined)[] = [];
-	$: inputTextareas = inputTextareas.filter((x) => x);
+	let inputTextareas = $state<(HTMLTextAreaElement | undefined)[]>([]);
+	let inputTextareaElements = $derived(
+		inputTextareas.filter((x) => x) as HTMLTextAreaElement[],
+	);
 	export function focus() {
-		inputTextareas[inputs.length - 1]?.focus();
+		inputTextareaElements[inputTextareaElements.length - 1].focus();
 	}
 
-	$: unconsumed = Math.max(
-		inputs.findLastIndex((input) => input.consumed !== ''),
-		0,
+	let unconsumed = $derived(
+		Math.max(
+			inputs.findLastIndex((input) => input.consumed !== ''),
+			0,
+		),
 	);
 
 	function addInput() {
@@ -37,7 +41,7 @@
 			inputs = [{ format: 'hex', consumed: '', queued: '' }];
 		}
 	}
-	$: ensureValid(inputs);
+	$effect(() => ensureValid(inputs));
 </script>
 
 <div class="inputs">
@@ -92,7 +96,7 @@
 								? 'Delete this input'
 								: 'Cannot delete consumed input'}
 							disabled={item.consumed !== '' || inputs.length === 1}
-							on:click={() => deleteInput(i)}
+							onclick={() => deleteInput(i)}
 						>
 							<span class="icon">
 								<Fa icon={faTrash} />
@@ -107,7 +111,7 @@
 		<button
 			class="button is-fullwidth"
 			title="Add additional inputs to the queue, possibly with a different format."
-			on:click={addInput}
+			onclick={addInput}
 		>
 			<span class="icon"> <Fa icon={faPlus}></Fa> </span>
 			<span>Add additional input</span>

--- a/src/lib/InstructionSet.svelte
+++ b/src/lib/InstructionSet.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+	import { MarieSim } from '../marie';
+	import { hex } from '../utils';
+</script>
+
+<div>
+	<div class="p-2 content">
+		<p>Syntax: <code>[Label, ]Operation[ Operand]</code></p>
+		<p>
+			The optional <code>Label</code> must not start with a number, and cannot
+			contain whitespace or commas.<br />
+			This may be used as an operand and resolves to the address of its instruction/directive.
+		</p>
+		<p>
+			The <code>Operation</code> is case-insensitive and may be an assembly directive
+			or instruction.
+		</p>
+		<p>
+			For instructions, the <code>Operand</code> may be a label, or a
+			hexadecimal value.<br />A leading zero is required if the first digit is
+			greater than 9.
+		</p>
+		<p>A forward slash <code>/</code> denotes a line comment.</p>
+	</div>
+	<table class="table is-striped is-fullwidth">
+		<thead>
+			<tr
+				><th title="Assembly directive">Directive</th><th
+					class="Directive description">Description</th
+				></tr
+			>
+		</thead>
+		<tbody>
+			<tr>
+				<td>DEC X</td>
+				<td>Literal signed/unsigned decimal value X.</td>
+			</tr>
+			<tr>
+				<td>HEX X</td>
+				<td>Literal hexadecimal value X.</td>
+			</tr>
+			<tr>
+				<td>OCT X</td>
+				<td>Literal octal value X.</td>
+			</tr>
+			<tr>
+				<td>ORG X</td>
+				<td>Starting address for program (hexadecimal).</td>
+			</tr>
+		</tbody>
+	</table>
+	<table class="table is-striped is-fullwidth">
+		<thead>
+			<tr>
+				<th title="Instruction name">Instruction</th>
+				<th title="Instruction description">Description</th>
+			</tr>
+		</thead>
+		<tbody>
+			{#each MarieSim.instructions as inst}
+				<tr>
+					<td
+						><div>
+							{inst.name}
+							{#if inst.operand}
+								X
+							{/if}
+						</div>
+						<div>
+							<code>0x{hex(inst.opcode, 1)}</code>
+						</div>
+					</td>
+					<td>
+						<div class="desc">{inst.description}</div>
+					</td>
+				</tr>
+			{/each}
+		</tbody>
+	</table>
+</div>
+
+<style>
+	.desc {
+		white-space: pre-wrap;
+	}
+</style>

--- a/src/lib/InstructionSet.svelte
+++ b/src/lib/InstructionSet.svelte
@@ -1,6 +1,32 @@
 <script lang="ts">
 	import { MarieSim } from '../marie';
 	import { hex } from '../utils';
+
+	const instructions = MarieSim.instructions.flatMap((instruction) => {
+		if (instruction.name === 'LoadImmi') {
+			return [
+				instruction,
+				{
+					name: 'Clear',
+					opcode: 0xa,
+					operand: false,
+					description: 'Alias for LoadImmi 0.\n\nAC ← 0',
+				},
+			];
+		}
+		if (instruction.name === 'JnS') {
+			return [
+				instruction,
+				{
+					name: 'Adr',
+					opcode: 0x0,
+					operand: true,
+					description: 'Alias for JnS X.',
+				},
+			];
+		}
+		return [instruction];
+	});
 </script>
 
 <div>
@@ -17,8 +43,8 @@
 		</p>
 		<p>
 			For instructions, the <code>Operand</code> may be a label, or a
-			hexadecimal value.<br />A leading zero is required if the first digit is
-			greater than 9.
+			hexadecimal value (which is usually an address).<br />A leading zero is
+			required if the first digit is greater than 9.
 		</p>
 		<p>A forward slash <code>/</code> denotes a line comment.</p>
 	</div>
@@ -57,10 +83,10 @@
 			</tr>
 		</thead>
 		<tbody>
-			{#each MarieSim.instructions as inst}
+			{#each instructions as inst}
 				<tr>
 					<td
-						><div>
+						><div class="name">
 							{inst.name}
 							{#if inst.operand}
 								X
@@ -80,6 +106,9 @@
 </div>
 
 <style>
+	.name {
+		white-space: nowrap;
+	}
 	.desc {
 		white-space: pre-wrap;
 	}

--- a/src/lib/LoadFromUrl.svelte
+++ b/src/lib/LoadFromUrl.svelte
@@ -1,15 +1,20 @@
 <script lang="ts">
-	import { createEventDispatcher } from 'svelte';
 	import Modal from './Modal.svelte';
 
-	export let active: boolean;
+	let {
+		active,
+		onLoadFromUrl,
+		onCancel,
+	}: {
+		active: boolean;
+		onLoadFromUrl: (url: string) => void;
+		onCancel: () => void;
+	} = $props();
 
-	const dispatch = createEventDispatcher();
+	let url = $state('');
+	let loading = $state(false);
 
-	let url = '';
-	let loading = false;
-
-	$: resetLoading(active);
+	$effect(() => resetLoading(active));
 
 	function resetLoading(active: boolean) {
 		loading = false;
@@ -19,36 +24,35 @@
 	function accept() {
 		if (!loading) {
 			loading = true;
-			dispatch('loadFromUrl', { url });
+			onLoadFromUrl(url);
 		}
 	}
 </script>
 
-<Modal
-	{active}
-	title="Load from URL"
-	on:cancel={() => () => dispatch('cancel')}
->
-	<div class="field">
-		<p class="control is-expanded">
-			<input class="input" type="text" bind:value={url} />
-		</p>
-	</div>
-	<div slot="footer">
+{#snippet footer()}
+	<div>
 		<button
 			class="button is-primary"
 			class:is-loading={loading}
-			on:click={accept}
+			onclick={accept}
 		>
 			Open
 		</button>
 		<button
 			type="button"
 			class="button"
-			on:click={() => dispatch('cancel')}
+			onclick={() => onCancel()}
 			disabled={loading}
 		>
 			Cancel
 		</button>
+	</div>
+{/snippet}
+
+<Modal {active} title="Load from URL" onCancel={() => onCancel()} {footer}>
+	<div class="field">
+		<p class="control is-expanded">
+			<input class="input" type="text" bind:value={url} />
+		</p>
 	</div>
 </Modal>

--- a/src/lib/OutputLog.svelte
+++ b/src/lib/OutputLog.svelte
@@ -62,20 +62,22 @@
 			</select>
 		</div>
 	</div>
-	<div class="log" bind:this={element}>
-		{#if outputs.length === 0}
-			<div class="has-text-centered has-text-grey">(no output)</div>
-		{:else if outputMode === 'unicode'}
-			<div class="unicode">
-				{showUnicode(outputs)}
-			</div>
-		{:else}
-			{#each outputs as output}
-				<div class="output">
-					{showValue(outputMode, output)}
+	<div class="log">
+		<div class="log-inner" bind:this={element}>
+			{#if outputs.length === 0}
+				<div class="has-text-centered has-text-grey">(no output)</div>
+			{:else if outputMode === 'unicode'}
+				<div class="unicode">
+					{showUnicode(outputs)}
 				</div>
-			{/each}
-		{/if}
+			{:else}
+				{#each outputs as output}
+					<div class="output">
+						{showValue(outputMode, output)}
+					</div>
+				{/each}
+			{/if}
+		</div>
 	</div>
 </div>
 
@@ -91,12 +93,15 @@
 		flex: 0 0 auto;
 	}
 	.log {
+		overflow: hidden;
 		flex: 1 1 auto;
-		overflow: auto;
-		padding: 1rem;
 		display: flex;
 		flex-direction: column;
 		justify-content: center;
+	}
+	.log-inner {
+		overflow: auto;
+		padding: 1rem;
 	}
 	.output {
 		text-align: right;

--- a/src/lib/OutputLog.svelte
+++ b/src/lib/OutputLog.svelte
@@ -3,10 +3,15 @@
 	import { bin, dec, hex, oct } from '../utils';
 	import type { InputOutputMode } from '../settings';
 
-	export let outputs: number[];
-	export let outputMode: InputOutputMode;
+	let {
+		outputs,
+		outputMode = $bindable(),
+	}: {
+		outputs: number[];
+		outputMode: InputOutputMode;
+	} = $props();
 
-	let element: HTMLDivElement | undefined;
+	let element = $state<HTMLDivElement>();
 
 	function showValue(mode: InputOutputMode, value: number) {
 		switch (mode) {
@@ -40,7 +45,9 @@
 			element.scrollTo(0, element.scrollHeight);
 		}
 	}
-	$: update(outputs);
+	$effect(() => {
+		update(outputs);
+	});
 </script>
 
 <div class="outputs">

--- a/src/lib/RTLLog.svelte
+++ b/src/lib/RTLLog.svelte
@@ -58,6 +58,8 @@
 						return `Is AC = 0? ${action.result ? 'Yes!' : 'No'}`;
 					case 'AC_POS':
 						return `Is AC > 0? ${action.result ? 'Yes!' : 'No'}`;
+					case 'AC_NON_ZERO':
+						return `Is AC ≠ 0? ${action.result ? 'Yes!' : 'No'}`;
 				}
 			case 'arithmetic':
 				switch (action.operation) {

--- a/src/lib/RTLLog.svelte
+++ b/src/lib/RTLLog.svelte
@@ -65,8 +65,8 @@
 						return 'AC ← AC + MBR';
 					case 'SUB':
 						return 'AC ← AC - MBR';
-					case 'CLEAR':
-						return 'AC ← 0';
+					case 'LOAD_IMMI':
+						return 'AC ← IR[11-0]';
 				}
 			case 'input':
 				return ['IN', dec(action.newInput)];

--- a/src/lib/Registers.svelte
+++ b/src/lib/Registers.svelte
@@ -1,25 +1,30 @@
 <script lang="ts">
-	import { createEventDispatcher } from 'svelte';
 	import { type Register, type Registers } from '../marie';
 	import HexCell from './HexCell.svelte';
-	export let registers: Registers;
-	export let readonly = false;
 
-	let hoverRegister: Register | null = null;
-	let editRegister: Register | null = null;
+	let {
+		registers,
+		readonly = false,
+		onHover,
+		onEditRegister,
+	}: {
+		registers: Registers;
+		readonly: boolean;
+		onHover: (register: Register | null) => void;
+		onEditRegister: (register: Register, value: number) => void;
+	} = $props();
 
-	const dispatch = createEventDispatcher();
+	let hoverRegister = $state<Register | null>(null);
+	let editRegister = $state<Register | null>(null);
 
-	$: dispatch('hover', {
-		register: editRegister === null ? hoverRegister : null,
-	});
+	$effect(() => onHover(editRegister === null ? hoverRegister : null));
 
 	function checkReadOnly(readonly: boolean) {
 		if (readonly) {
 			editRegister = null;
 		}
 	}
-	$: checkReadOnly(readonly);
+	$effect(() => checkReadOnly(readonly));
 
 	function edit(register: Register) {
 		if (!readonly) {
@@ -32,25 +37,23 @@
 
 <div class="registers">
 	{#each regs as reg}
-		<!-- svelte-ignore a11y-no-static-element-interactions -->
-		<!-- svelte-ignore a11y-mouse-events-have-key-events -->
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
 		<div
 			class={`register register-${reg}`}
-			on:mouseenter={() => (hoverRegister = reg)}
-			on:mouseleave={() => (hoverRegister = null)}
+			onmouseenter={() => (hoverRegister = reg)}
+			onmouseleave={() => (hoverRegister = null)}
 		>
 			<div class="name">{reg}</div>
-			<!-- svelte-ignore a11y-no-static-element-interactions -->
-			<div class="value" on:dblclick={() => edit(reg)}>
+			<div class="value" ondblclick={() => edit(reg)}>
 				<HexCell
 					value={registers[reg]}
 					editing={editRegister === reg}
 					digits={reg === 'PC' || reg === 'MAR' ? 3 : 4}
-					on:edit={(e) => {
-						dispatch('edit-register', { register: reg, value: e.detail.value });
+					onEdit={(value) => {
+						onEditRegister(reg, value);
 						editRegister = null;
 					}}
-					on:cancel={() => (editRegister = null)}
+					onCancel={() => (editRegister = null)}
 				/>
 			</div>
 		</div>

--- a/src/lib/ShareUrl.svelte
+++ b/src/lib/ShareUrl.svelte
@@ -3,23 +3,32 @@
 	import Modal from './Modal.svelte';
 	import { faClipboard } from '@fortawesome/free-solid-svg-icons';
 
-	export let shareUrl: string | null = null;
+	let { shareUrl = null }: { shareUrl: string | null } = $props();
 
-	let shareUrlInput: HTMLInputElement;
-	let copiedShareUrl = false;
+	let shareUrlInput = $state<HTMLInputElement>();
+	let copiedShareUrl = $state(false);
 
 	function copyShareUrl() {
-		shareUrlInput.select();
-		shareUrlInput.setSelectionRange(0, shareUrl!.length);
+		shareUrlInput?.select();
+		shareUrlInput?.setSelectionRange(0, shareUrl!.length);
 		navigator.clipboard.writeText(shareUrl!);
 		copiedShareUrl = true;
 	}
 </script>
 
+{#snippet footer()}
+	<div>
+		<button class="button is-primary" onclick={() => (shareUrl = null)}>
+			Done
+		</button>
+	</div>
+{/snippet}
+
 <Modal
 	active={shareUrl !== null}
 	title="Share this program"
-	on:cancel={() => (shareUrl = null)}
+	onCancel={() => (shareUrl = null)}
+	{footer}
 >
 	<div class="field has-addons">
 		<p class="control is-expanded">
@@ -28,7 +37,7 @@
 				class="input"
 				type="text"
 				value={shareUrl}
-				on:click={() => shareUrlInput.select()}
+				onclick={() => shareUrlInput?.select()}
 				readonly
 			/>
 		</p>
@@ -38,15 +47,10 @@
 				class="button"
 				class:is-primary={!copiedShareUrl}
 				class:is-success={copiedShareUrl}
-				on:click={copyShareUrl}
+				onclick={copyShareUrl}
 			>
 				<span class="icon"><Fa icon={faClipboard} /></span>
 			</button>
 		</p>
-	</div>
-	<div slot="footer">
-		<button class="button is-primary" on:click={() => (shareUrl = null)}>
-			Done
-		</button>
 	</div>
 </Modal>

--- a/src/lib/Spinner.svelte
+++ b/src/lib/Spinner.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import { fade } from 'svelte/transition';
-	export let active = false;
+	let { active = false } = $props();
 
 	let beforeShowTimer: NodeJS.Timeout | null = null;
 	let afterShowTimer: NodeJS.Timeout | null = null;
 
-	let state = 0;
+	let state = $state(0);
 
-	$: onActiveChanged(active);
+	$effect(() => onActiveChanged(active));
 
 	function onActiveChanged(active: boolean) {
 		if (active) {

--- a/src/lib/WatchList.svelte
+++ b/src/lib/WatchList.svelte
@@ -2,13 +2,18 @@
 	import Fa from 'svelte-fa';
 	import { bin, dec, hex, oct } from '../utils';
 	import { faArrowRight } from '@fortawesome/free-solid-svg-icons';
-	import { createEventDispatcher } from 'svelte';
 
-	export let symbols: { [label: string]: number | undefined };
-	export let pointers: { [label: string]: boolean | undefined };
-	export let memory: number[];
-
-	const dispatch = createEventDispatcher();
+	let {
+		symbols,
+		pointers = $bindable(),
+		memory,
+		onHoverWatch,
+	}: {
+		symbols: { [label: string]: number | undefined };
+		pointers: { [label: string]: boolean | undefined };
+		memory: number[];
+		onHoverWatch: (address: number | null) => void;
+	} = $props();
 
 	function getItems(
 		symbols: { [label: string]: number | undefined },
@@ -31,7 +36,7 @@
 			};
 		});
 	}
-	$: items = getItems(symbols, pointers, memory);
+	let items = $derived(getItems(symbols, pointers, memory));
 </script>
 
 <div class="watches">
@@ -50,9 +55,8 @@
 			<tbody>
 				{#each items as item}
 					<tr
-						on:mouseenter={() =>
-							dispatch('hover-watch', { address: item.address })}
-						on:mouseleave={() => dispatch('hover-watch', { address: null })}
+						onmouseenter={() => onHoverWatch(item.address)}
+						onmouseleave={() => onHoverWatch(null)}
 					>
 						<td>
 							<div
@@ -67,7 +71,7 @@
 											title={pointers[item.label]
 												? 'Click to interpret directly'
 												: 'Click to interpret as pointer'}
-											on:click={() =>
+											onclick={() =>
 												(pointers[item.label] = !pointers[item.label])}
 										>
 											<Fa icon={faArrowRight} />

--- a/src/marie.ts
+++ b/src/marie.ts
@@ -35,7 +35,11 @@ export type State = {
 export type ArithmeticOperation = 'ADD' | 'SUB' | 'LOAD_IMMI';
 
 /** Comparison operations which can be performed by the ALU */
-export type ComparisonOperation = 'AC_NEG' | 'AC_ZERO' | 'AC_POS';
+export type ComparisonOperation =
+	| 'AC_NEG'
+	| 'AC_ZERO'
+	| 'AC_POS'
+	| 'AC_NON_ZERO';
 
 /** Actions recorded in the replay log */
 export type Action =
@@ -686,6 +690,9 @@ export class MarieSim {
 			case 'AC_POS':
 				result = this._registers.AC !== 0 && this._registers.AC >> 15 === 0;
 				break;
+			case 'AC_NON_ZERO':
+				result = this._registers.AC !== 0;
+				break;
 		}
 		const oldResult = this._comparisonResult;
 		this._comparisonResult = result;
@@ -881,6 +888,8 @@ export class MarieSim {
 							return sim.comparisonOperation('AC_ZERO');
 						case 0x800:
 							return sim.comparisonOperation('AC_POS');
+						case 0xc00:
+							return sim.comparisonOperation('AC_NON_ZERO');
 
 						default:
 							sim._halted = true;
@@ -898,7 +907,7 @@ export class MarieSim {
 				(sim) => (sim._comparisonResult ? sim.incrementPC() : null),
 			],
 			description:
-				'Skip the next instruction if the condition indicated by X holds:\n- 000: Skip if AC < 0\n- 400: Skip if AC = 0\n- 800: Skip if AC > 0',
+				'Skip the next instruction if the condition indicated by X holds:\n- 000: Skip if AC < 0\n- 400: Skip if AC = 0\n- 800: Skip if AC > 0\n- 0C00: Skip if AC ≠ 0',
 		},
 		{
 			name: 'JnS',

--- a/src/marie.ts
+++ b/src/marie.ts
@@ -32,7 +32,7 @@ export type State = {
 };
 
 /** Arithmetic operations which can be performed by the ALU */
-export type ArithmeticOperation = 'ADD' | 'SUB' | 'CLEAR';
+export type ArithmeticOperation = 'ADD' | 'SUB' | 'LOAD_IMMI';
 
 /** Comparison operations which can be performed by the ALU */
 export type ComparisonOperation = 'AC_NEG' | 'AC_ZERO' | 'AC_POS';
@@ -660,8 +660,8 @@ export class MarieSim {
 				this._registers.AC =
 					(this._registers.AC - this._registers.MBR) & 0xffff;
 				break;
-			case 'CLEAR':
-				this._registers.AC = 0;
+			case 'LOAD_IMMI':
+				this._registers.AC = this._registers.IR & 0xfff;
 				break;
 		}
 		return {
@@ -781,11 +781,12 @@ export class MarieSim {
 				'Use the contents at address X as the address of the value to add to the AC.\n\nAC ← AC + M[M[X]]',
 		},
 		{
-			name: 'Clear',
+			name: 'LoadImmi',
 			opcode: 0xa,
-			operand: false,
-			microSteps: [(sim) => sim.arithmeticOperation('CLEAR')],
-			description: 'Set the AC to 0.\n\nAC ← 0',
+			operand: true,
+			microSteps: [(sim) => sim.arithmeticOperation('LOAD_IMMI')],
+			description:
+				'Set the AC to the given 12-bit unsigned immediate value X.\n\nAC ← X',
 		},
 		{
 			name: 'Load',
@@ -1134,6 +1135,10 @@ export function assemble(code: string): AssemblyResult {
 				break;
 			case 'adr':
 				instruction.operator = 'jns';
+				break;
+			case 'clear':
+				instruction.operator = 'loadimmi';
+				instruction.operand = '0';
 				break;
 		}
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -18,6 +18,7 @@ export interface Settings {
 	leftPanel: number;
 	topPanel: number;
 	editorPanel: number;
+	instructionPanel: number;
 	outputLogOpen: boolean;
 	rtlLogOpen: boolean;
 	watchListOpen: boolean;
@@ -34,6 +35,7 @@ export const settings = writable<Settings>(
 			leftPanel: 70,
 			topPanel: 70,
 			editorPanel: 50,
+			instructionPanel: 70,
 			outputLogOpen: true,
 			rtlLogOpen: false,
 			watchListOpen: false,

--- a/src/syntax.ts
+++ b/src/syntax.ts
@@ -20,7 +20,7 @@ const syntax = simpleMode({
 		}, // Labels
 		{
 			regex:
-				/(?:add|subt|addi|load|loadi|store|storei|jump|skipcond|jns|jumpi|adr)\b\s*/i,
+				/(?:add|subt|addi|load|loadi|loadimmi|store|storei|jump|skipcond|jns|jumpi|adr)\b\s*/i,
 			token: 'keyword',
 			next: 'operand',
 		}, // Operator
@@ -159,6 +159,8 @@ export function getCompletions(
 			label: instruction.name,
 			info: `${instruction.name}${instruction.operand ? ' X' : ''}\n\n${instruction.description}`,
 		})),
+		{ label: 'Adr', info: 'Adr X\n\nAlias for JnS X.' },
+		{ label: 'Clear', info: 'Clear\n\nAlias for LoadImmi 0.' },
 	);
 	return {
 		from: nodeBefore.from,


### PR DESCRIPTION
These changes are deployed [here](https://cyderize.github.io/MARIE.js/).

Bug fixes:
- Fix a bug where long output in the output window was unable to be scrolled all the way to the top

Language changes:
- Change the `0xA` opcode to `LoadImmi X`, which loads a 12-bit unsigned immediate value into the `AC`.
- Change `Clear` to be an alias for `LoadImmi 0`
- Allow using `0C00` as the operand for `SkipCond` to allow for skipping when the AC is non-zero.

Editor features:
- Add an instruction set button to the toolbar which shows help for syntax and instructions
- Enable using `Ctrl+/` to toggle line comments
- Allow auto-complete to appear in more situations with proper context sensitive suggestions
- Show instruction and label details in auto-complete prompts
- Show tooltip with details when hovering over instructions in the code
- Make the user input prompt more visible when an `Input` instruction is executed
- Improve text contrast in the status bar

Code changes:
- Update code to use Svelte 5 Runes (was previously written for Svelte 4)