### PR TITLE
Fix auto-scrolling for source editor and RTL log during stepping

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -175,11 +175,13 @@
 	function onStep(didAction: boolean) {
 		if (didAction) {
 			setStatus('Executed one step.');
+			editor?.scrollToPC();
 		}
 	}
 	function onMicroStep(type?: string) {
 		if (type === 'step-end') {
 			setStatus('Completed executing instruction.');
+			editor?.scrollToPC();
 		} else {
 			setStatus('Executed one microstep.');
 		}

--- a/src/lib/Display.svelte
+++ b/src/lib/Display.svelte
@@ -11,7 +11,7 @@
 </script>
 
 <div class="display">
-	<div>16x16 display, 0xF00-0xFFF:</div>
+	<div>16x16 display, 0xF00-0xFFF. Pixel: R[14-10] G[9-5] B[4-0]</div>
 	<div class="pixels">
 		{#each [...Array(16)].map((_, i) => i) as i}
 			<div class="row">

--- a/src/lib/RTLLog.svelte
+++ b/src/lib/RTLLog.svelte
@@ -78,15 +78,17 @@
 		return null;
 	}
 
-	async function update(steps: Step[]) {
-		startStep = Math.max(0, steps.length - 5);
+	let actionCount = $derived(steps.reduce((n, s) => n + s.actions.length, 0));
+
+	async function update(_steps: Step[], _actionCount: number) {
+		startStep = Math.max(0, _steps.length - 5);
 		await tick();
 		if (element) {
 			element.scrollTo(0, element.scrollHeight);
 		}
 	}
 	$effect(() => {
-		update(steps);
+		update(steps, actionCount);
 	});
 
 	async function showPrevious() {

--- a/src/lib/Simulator.svelte
+++ b/src/lib/Simulator.svelte
@@ -112,6 +112,7 @@
 		}
 		if (breakpoints[line]) {
 			running = false;
+			forceUpdateState();
 			onBreak(line);
 		}
 	}


### PR DESCRIPTION
- Source editor now scrolls to keep the current PC line visible when stepping, micro-stepping, or hitting a breakpoint (previously only scrolled on run-pause and input-pause)
- RTL log now auto-scrolls to bottom during micro-stepping (the `$effect()` watching `steps` wasn't re-triggering because micro-step mutations within existing step objects don't change the array reference)
- Added RGB pixel format hint (R[14-10] G[9-5] B[4-0]) to the `Display` panel label
